### PR TITLE
Add options.dir to manage directory settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
+images/
 test/img/
 sample/img/
+sample/images/
 sample/.cache/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Low level utility to perform build-time image transformations.
   * Keeps original image aspect ratios intact.
   * Never upscales images larger than original size.
 * Output multiple image formats.
-  * The [sharp](https://sharp.pixelplumbing.com/) image processor supports `jpeg`, `png`, `webp`, `raw`, and `tiff`.
+  * The [sharp](https://sharp.pixelplumbing.com/) image processor supports `jpeg`, `png`, and `webp`.
   * Incoming `gif` and `svg` images are converted to `png`.
 * Cache remote images locally using [eleventy-cache-assets](https://github.com/11ty/eleventy-cache-assets).
   * Use "local" images in your HTML to prevent broken image URLs.
@@ -31,9 +31,16 @@ npm install @11ty/eleventy-img
 
 const Image = require("@11ty/eleventy-img");
 module.exports = function(eleventyConfig) {
-  eleventyConfig.addJavaScriptFunction("myImage", function(src, alt, options) {
+  eleventyConfig.addJavaScriptFunction("myImagePromise", function(src, alt, options) {
     // returns Promise
     return Image(src, options);
+  });
+
+  eleventyConfig.addJavaScriptFunction("myImage", async function(src, alt, options) {
+    let stats = await Image(src, options);
+    let props = stats['jpeg'].pop();
+    // returns String
+    return `<img src="${props.url} alt="${alt}">`;
   });
 };
 ```
@@ -51,10 +58,10 @@ Defaults values are shown:
   // widths: [200, null] // output 200px and original width
 
   // output image formats
-  formats: ["webp", "jpeg"], // also supported by sharp: "png", "raw", "tiff"
+  formats: ["webp", "jpeg"], // also supported by sharp: "png"
 
   dir: {
-    // directory for the image src URLs
+    // image directory to use in img src
     imgSrc: "/img/", // <img src="/img/MY_IMAGE.png">
     // project-relative directory to write the image files
     output: "./", // ./img/
@@ -77,33 +84,38 @@ Defaults values are shown:
 
 See all [relevant `eleventy-cache-assets` options in its documentation](https://github.com/11ty/eleventy-cache-assets/blob/master/README.md#options).
 
+### Image Processing Concurrency
+
+```js
+const Image = require("@11ty/eleventy-img");
+Image.concurrency = 4; // default is 10
+```
+
 ## Examples
 
-> Requires `async`, make sure you’re using this in Liquid, 11ty.js, or Nunjucks (use an async shortcode).
+> NOTE: The examples below use the [Nunjucks](https://www.11ty.dev/docs/languages/nunjucks/#asynchronous-shortcodes) `async` shortcodes (the [JavaScript](https://www.11ty.dev/docs/languages/javascript/#asynchronous-javascript-template-functions) and [Liquid](https://www.11ty.dev/docs/languages/liquid/#asynchronous-shortcodes) template engines are async by default).
 
-### Specifying Image Source and Output Directories
+### Specify Image Source and Output Directories
 
 #### Input for Specified Directories
 
 ```js
 const Image = require("@11ty/eleventy-img");
 module.exports = function(eleventyConfig) {
-  // works also with addLiquidShortcode or addNunjucksAsyncShortcode
-  eleventyConfig.addJavaScriptFunction("myImage", async function(src, alt, outputFormat = "jpeg") {
+  // works also with addLiquidShortcode or addJavaScriptFunction
+  eleventyConfig.addNunjucksAsyncShortcode("myImage", async function(src, alt, outputFormat = "jpeg") {
     if(alt === undefined) {
       // You bet we throw an error on missing alt (alt="" works okay)
       throw new Error(`Missing \`alt\` on myImage from: ${src}`);
     }
 
-    // returns Promise
     let stats = await Image(src, {
       formats: [outputFormat],
       dir: {
         imgSrc: "/assets/img/",
-        output: "_site/",
+        output: "./_site/",
       },
     });
-
     let props = stats[outputFormat].pop();
 
     return `<img src="${props.src}" width="${props.width}" height="${props.height}" alt="${alt}">`;
@@ -131,7 +143,7 @@ module.exports = function(eleventyConfig) {
 ┊
 ├─ _site
 │  ├─ assets
-│  │  ├─ css
+│  │  ┊
 │  │  ├─ img
 │  │  │  ├─ 2311v21.jpeg
 │  │  │  └─ 3d00b40.jpeg
@@ -142,16 +154,16 @@ module.exports = function(eleventyConfig) {
 <!-- dist/index.html -->
 
 <div>
-  <img src="/assets/img/3d00b40.jpeg" width="50" height="50" alt="photo of my cat">
+  <img src="/assets/img/3d00b40.jpeg" width="1200" height="750" alt="photo of my cat">
 </div>
 <div>
-  <img src="/assets/img/2311v21.jpeg" width="50" height="50" alt="photo of my dog">
+  <img src="/assets/img/2311v21.jpeg" width="1200" height="750" alt="photo of my dog">
 </div>
 ```
 
-### Output Optimized Images with Width/Height Attributes
+### Specify Output Width
 
-#### Inputs for Optimized Images
+#### Inputs for Specified Width
 
 ```js
 /* .eleventy.js */
@@ -165,15 +177,13 @@ module.exports = function(eleventyConfig) {
       throw new Error(`Missing \`alt\` on myImage from: ${src}`);
     }
 
-    // returns Promise
     let stats = await Image(src, {
-      widths: [50],
       formats: [outputFormat],
+      widths: [600],
     });
-
     let props = stats[outputFormat].pop();
 
-    return `<img src="${props.src}" width="${props.width}" height="${props.height}" alt="${alt}">`;
+    return `<img src="${props.url}" width="${props.width}" height="${props.height}" alt="${alt}">`;
   });
 };
 ```
@@ -189,20 +199,31 @@ module.exports = function(eleventyConfig) {
 </div>
 ```
 
-#### Output for Optimized Images
+#### Output for Specified Width
+
+```sh
+# project file system
+
+├─ .eleventy.js
+┊
+├─ img
+│  ├─ 2311v21-600.jpeg
+│  └─ 3d00b40-600.jpeg
+┊
+```
 
 ```html
 <!-- dist/index.html -->
 
 <div>
-  <img src="/img/3d00b40-50.jpeg" width="50" height="50" alt="photo of my cat">
+  <img src="/img/3d00b40-600.jpeg" width="600" height="375" alt="photo of my cat">
 </div>
 <div>
-  <img src="/img/2311v21-50.jpeg" width="50" height="50" alt="photo of my dog">
+  <img src="/img/2311v21-600.jpeg" width="600" height="375" alt="photo of my dog">
 </div>
 ```
 
-### Output Optimized Multi-Format, Multi-Size Responsive Images using `<picture>`
+### Specify Multi-Format, Multi-Size Responsive Images using `<picture>`
 
 #### Inputs for Responsive Images
 
@@ -212,29 +233,38 @@ module.exports = function(eleventyConfig) {
 const Image = require("@11ty/eleventy-img");
 module.exports = function(eleventyConfig) {
   // works also with addLiquidShortcode or addJavaScriptFunction
-  eleventyConfig.addNunjucksAsyncShortcode("myResponsiveImage", async function(src, alt, outputFormat = "jpeg") {
+  eleventyConfig.addNunjucksAsyncShortcode("myResponsiveImage", async function(src, alt, outputFormats = "jpeg") {
     if(alt === undefined) {
       // You bet we throw an error on missing alt (alt="" works okay)
       throw new Error(`Missing \`alt\` on myResponsiveImage from: ${src}`);
     }
 
-    let stats = await Image(src, {
-      widths: [null],
-      formats: [outputFormat],
-    });
-    let lowestSrc = stats[outputFormat][0];
     let sizes = "100vw"; // Make sure you customize this!
+    // Note: the order of outputFormats matters, preferred formats should be listed first
+    let formats = outputFormats.split(",").map(txt => txt.trim());
+
+    let stats = await Image(src, {
+      formats,
+      widths: [400, 800, null],
+    });
+
+    let sourceBlock = Object.values(stats).map((imageFormat) => `<source
+      type="image/${imageFormat[0].format}"
+      srcset="${imageFormat.map((entry) => `${entry.url} ${entry.width}w`).join(', ')}"
+      sizes="${sizes}">`)
+      .join('\n');
+    // Default output format should be listed last
+    let defaultSrc = stats[formats.slice(-1)][0];
+    let imgBlock = `<img
+      src="${defaultSrc.url}"
+      width="${defaultSrc.width}"
+      height="${defaultSrc.height}"
+      alt="${alt}">`;
 
     // Iterate over formats and widths
     return `<picture>
-      ${Object.values(stats).map(imageFormat => {
-        return `  <source type="image/${imageFormat[0].format}" srcset="${imageFormat.map(entry => `${entry.src} ${entry.width}w`).join(", ")}" sizes="${sizes}">`;
-      }).join("\n")}
-        <img
-          src="${lowestSrc.src}"
-          width="${lowestSrc.width}"
-          height="${lowestSrc.height}"
-          alt="${alt}">
+        ${sourceBlock}
+        ${imgBlock}
       </picture>`;
     });
 };
@@ -244,28 +274,51 @@ module.exports = function(eleventyConfig) {
 <!-- index.njk -->
 
 <div>
-  {% myResponsiveImage "./src/images/cat.jpg", "photo of my cat"}
+  {% myResponsiveImage "./src/images/cat.jpg", "photo of my cat", "webp,jpeg" %}
 </div>
 <div>
-  {% myResponsiveImage "https://my_site.com/assets/img/dog.jpg", "photo of my dog" %}
+  {% myResponsiveImage "https://my_site.com/assets/img/dog.jpg", "photo of my dog", "webp,jpeg" %}
 </div>
 ```
 
 #### Output for Responsive Images
+
+```sh
+# project file system
+
+├─ .eleventy.js
+┊
+├─ img
+│  ├─ 2311v21.jpeg
+│  ├─ 2311v21.webp
+│  ├─ 2311v21-400.jpeg
+│  ├─ 2311v21-400.webp
+│  ├─ 2311v21-800.jpeg
+│  ├─ 2311v21-800.webp
+│  ├─ 3d00b40.jpeg
+│  ├─ 3d00b40.webp
+│  ├─ 3d00b40-400.jpeg
+│  ├─ 3d00b40-400.webp
+│  ├─ 3d00b40-800.jpeg
+│  └─ 3d00b40-800.webp
+┊
+```
 
 ```html
 <!-- dist/index.html -->
 
 <div>
   <picture>
-    <source type="image/jpeg" srcset="/img/3d00b40-96.jpeg 100w" sizes="100vw">
-    <img src="/img/3d00b40.jpeg" width="100" height="100" alt="photo of my cat">
+    <source type="image/jpeg" srcset="/img/3d00b40-400.jpeg 400w, /img/3d00b40-800.jpeg 800w, /img/3d00b40.jpeg 1200w" sizes="100vw">
+    <source type="image/webp" srcset="/img/3d00b40-400.webp 400w, /img/3d00b40-800.webp 800w, /img/3d00b40.webp 1200w" sizes="100vw">
+    <img src="/img/3d00b40-400.jpeg" width="400" height="250" alt="photo of my cat">
   </picture>
 </div>
 <div>
   <picture>
-    <source type="image/jpeg" srcset="/img/2311v21-75.jpeg 100w" sizes="100vw">
-    <img src="/img/2311v21.jpeg" width="100" height="100" alt="photo of my dog">
+    <source type="image/jpeg" srcset="/img/2311v21-400.jpeg 400w, /img/2311v21-800.jpeg 800w, /img/2311v21.jpeg 1200w" sizes="100vw">
+    <source type="image/webp" srcset="/img/2311v21-400.webp 400w, /img/2311v21-800.webp 800w, /img/2311v21.webp 1200w" sizes="100vw">
+    <img src="/img/2311v21-400.jpeg" width="400" height="250" alt="photo of my dog">
   </picture>
 </div>
 ```
@@ -278,52 +331,45 @@ Use this object to generate your responsive image markup.
 {
   webp: [
     {
-      format: 'webp',
+      format: "webp",
       width: 1280,
       height: 853,
-      sourceType: 'image/webp',
-      src: '/img/9b186f9b.webp',
-      srcset: '/img/9b186f9b.webp 1280w',
-      outputPath: 'img/9b186f9b.webp',
+      sourceType: "image/webp",
+      url: "/img/9b186f9b.webp",
+      srcset: "/img/9b186f9b.webp 1280w",
+      outputPath: "img/9b186f9b.webp",
       size: 213802
     }, {
-      format: 'webp',
+      format: "webp",
       width: 350,
       height: 233,
-      sourceType: 'image/webp',
-      src: '/img/9b186f9b-350.webp',
-      srcset: '/img/9b186f9b-350.webp 350w',
-      outputPath: 'img/9b186f9b-350.webp',
+      sourceType: "image/webp",
+      url: "/img/9b186f9b-350.webp",
+      srcset: "/img/9b186f9b-350.webp 350w",
+      outputPath: "img/9b186f9b-350.webp",
       size: 27288
     }
   ],
   jpeg: [
     {
-      format: 'jpeg',
+      format: "jpeg",
       width: 1280,
       height: 853,
-      sourceType: 'image/jpg',
-      src: '/img/9b186f9b.jpeg',
-      srcset: '/img/9b186f9b.jpeg 1280w',
-      outputPath: 'img/9b186f9b.jpeg',
+      sourceType: "image/jpg",
+      url: "/img/9b186f9b.jpeg",
+      srcset: "/img/9b186f9b.jpeg 1280w",
+      outputPath: "img/9b186f9b.jpeg",
       size: 276231
     }, {
-      format: 'jpeg',
+      format: "jpeg",
       width: 350,
       height: 233,
-      sourceType: 'image/jpg',
-      src: '/img/9b186f9b-350.jpeg',
-      srcset: '/img/9b186f9b-350.jpeg 350w',
-      outputPath: 'img/9b186f9b-350.jpeg',
+      sourceType: "image/jpg",
+      url: "/img/9b186f9b-350.jpeg",
+      srcset: "/img/9b186f9b-350.jpeg 350w",
+      outputPath: "img/9b186f9b-350.jpeg",
       size: 29101
     }
   ]
 }
-```
-
-### Change Global Plugin Concurrency
-
-```js
-const Image = require("@11ty/eleventy-img");
-Image.concurrency = 4; // default is 10
 ```

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ Defaults values are shown:
   // Pass any format supported by sharp
   formats: ["webp", "jpeg"], //"png"
 
-  // the directory in the image URLs <img src="/img/MY_IMAGE.png">
-  urlPath: "/img/",
-
-  // the path to the directory on the file system to write the image files to disk
-  outputDir: "img/",
+  dir: {
+    // the file system directory to write the image files to disk
+    output: "./",
+    // the directory in the image src URLs <img src="/img/MY_IMAGE.png">
+    imgSrc: "/img/"
+  },
 
   // eleventy-cache-assets
   // If a remote image URL, this is the amount of time before it downloads a new fresh copy from the remote server
@@ -55,9 +56,39 @@ Defaults values are shown:
 
 ## Examples
 
-### Output an Optimized Image with Width/Height Attributes
+> Requires `async`, make sure you’re using this in Liquid, 11ty.js, or Nunjucks (use an async shortcode).
 
-* Requires `async`, make sure you’re using this in Liquid, 11ty.js, or Nunjucks (use an async shortcode).
+### Specifying Output and Image Source Directories
+
+```js
+const Image = require("@11ty/eleventy-img");
+module.exports = function(eleventyConfig) {
+  // works also with addLiquidShortcode or addNunjucksAsyncShortcode
+  eleventyConfig.addJavaScriptFunction("myImage", async function(src, alt, outputFormat = "jpeg") {
+    if(alt === undefined) {
+      // You bet we throw an error on missing alt (alt="" works okay)
+      throw new Error(`Missing \`alt\` on myImage from: ${src}`);
+    }
+
+    // returns Promise
+    let stats = await Image(src, {
+      formats: [outputFormat],
+      dir: {
+        // Set the file system directory for saving images (_site/images/)
+        output: "_site/",
+        // Set the output img src directory (<img src="/images/MY_IMAGE.jpeg" alt="my pic">)
+        imgSrc: "/images/"
+      }
+    });
+
+    let props = stats[outputFormat].pop();
+
+    return `<img src="${props.src}" width="${props.width}" height="${props.height}" alt="${alt}">`;
+  });
+};
+```
+
+### Output an Optimized Image with Width/Height Attributes
 
 ```js
 const Image = require("@11ty/eleventy-img");

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = function(eleventyConfig) {
 
     let props = stats[outputFormat].pop();
 
-    return `<img src="${props.url}" width="${props.width}" height="${props.height}" alt="${alt}">`;
+    return `<img src="${props.src}" width="${props.width}" height="${props.height}" alt="${alt}">`;
   });
 };
 ```
@@ -104,11 +104,11 @@ module.exports = function(eleventyConfig) {
     // Iterate over formats and widths
     return `<picture>
       ${Object.values(stats).map(imageFormat => {
-        return `  <source type="image/${imageFormat[0].format}" srcset="${imageFormat.map(entry => `${entry.url} ${entry.width}w`).join(", ")}" sizes="${sizes}">`;
+        return `  <source type="image/${imageFormat[0].format}" srcset="${imageFormat.map(entry => `${entry.src} ${entry.width}w`).join(", ")}" sizes="${sizes}">`;
       }).join("\n")}
         <img
           alt="${alt}"
-          src="${lowestSrc.url}"
+          src="${lowestSrc.src}"
           width="${lowestSrc.width}"
           height="${lowestSrc.height}">
       </picture>`;
@@ -125,16 +125,16 @@ Use this object to generate your responsive image markup.
    [ { format: 'webp',
        width: 1280,
        height: 853,
-       url: '/img/9b186f9b.webp',
        sourceType: 'image/webp',
+       src: '/img/9b186f9b.webp',
        srcset: '/img/9b186f9b.webp 1280w',
        outputPath: 'img/9b186f9b.webp',
        size: 213802 },
      { format: 'webp',
        width: 350,
        height: 233,
-       url: '/img/9b186f9b-350.webp',
        sourceType: 'image/webp',
+       src: '/img/9b186f9b-350.webp',
        srcset: '/img/9b186f9b-350.webp 350w',
        outputPath: 'img/9b186f9b-350.webp',
        size: 27288 } ],
@@ -142,16 +142,16 @@ Use this object to generate your responsive image markup.
    [ { format: 'jpeg',
        width: 1280,
        height: 853,
-       url: '/img/9b186f9b.jpeg',
        sourceType: 'image/jpg',
+       src: '/img/9b186f9b.jpeg',
        srcset: '/img/9b186f9b.jpeg 1280w',
        outputPath: 'img/9b186f9b.jpeg',
        size: 276231 },
      { format: 'jpeg',
        width: 350,
        height: 233,
-       url: '/img/9b186f9b-350.jpeg',
        sourceType: 'image/jpg',
+       src: '/img/9b186f9b-350.jpeg',
        srcset: '/img/9b186f9b-350.jpeg 350w',
        outputPath: 'img/9b186f9b-350.jpeg',
        size: 29101 } ] }

--- a/img.js
+++ b/img.js
@@ -205,7 +205,7 @@ queue.on("active", () => {
  * Build the output directory path from the independent dir options (dir.imgSrc and dir.output)
  */
 function getOptions(opts) {
-  if(opts === undefined || opts.dir === undefined) {
+  if(opts === undefined) {
     return Object.assign({}, globalOptions);
   }
 
@@ -216,19 +216,21 @@ function getOptions(opts) {
 
   let options = Object.assign({}, opts);
 
-  if(opts.dir.imgSrc !== undefined) {
-    options.urlPath = opts.dir.imgSrc;
-    // set initial outputDir value (may be overwritten below)
-    options.outputDir = setOutputRootDir(opts.dir.imgSrc);
-  }
+  if(opts.dir !== undefined) {
+    if(opts.dir.imgSrc !== undefined) {
+      options.urlPath = opts.dir.imgSrc;
+      // set initial outputDir value (may be overwritten below)
+      options.outputDir = setOutputRootDir(opts.dir.imgSrc);
+    }
 
-  if(opts.dir.output !== undefined) {
-    // combine dir.output and dir.imgSrc into outputDir
-    options.outputDir = path.join(setOutputRootDir(opts.dir.output), (options.urlPath || globalOptions.urlPath));
-  }
+    if(opts.dir.output !== undefined) {
+      // combine dir.output and dir.imgSrc into outputDir
+      options.outputDir = path.join(setOutputRootDir(opts.dir.output), (options.urlPath || globalOptions.urlPath));
+    }
 
-  // cleanup before merging with global options
-  delete options.dir;
+    // cleanup before merging with global options
+    delete options.dir;
+  }
 
   return Object.assign({}, globalOptions, options);
 }

--- a/img.js
+++ b/img.js
@@ -202,38 +202,35 @@ queue.on("active", () => {
 });
 
 /*
- * Merge dir options (imgSrc and output) into urlPath and outputDir
- * TODO: deprecate outputDir and urlPath?
+ * Build the output directory path from the independent dir options (dir.imgSrc and dir.output)
  */
 function getOptions(opts) {
-  if(opts === undefined) {
+  if(opts === undefined || opts.dir === undefined) {
     return Object.assign({}, globalOptions);
   }
 
-  /*
-   * Make sure outputDir is not pointing to file system root dir
-   */
-  function setDirLocal(dirString) {
-    return dirString.replace(/^\//, './');
+  // Set project-relative output root directory
+  function setOutputRootDir(directory) {
+    return path.join('./', directory);
   }
 
-  const newOpts = Object.assign({}, opts);
+  let options = Object.assign({}, opts);
 
-  if(opts.dir !== undefined) {
-    if(opts.dir.imgSrc !== undefined) {
-      newOpts.urlPath = opts.dir.imgSrc;
-      // set initial outputDir value (may be overwritten below)
-      newOpts.outputDir = setDirLocal(opts.dir.imgSrc);
-    }
-    if(opts.dir.output !== undefined) {
-      // combine dir.output and dir.imgSrc into outputDir
-      newOpts.outputDir = path.join(setDirLocal(opts.dir.output), (newOpts.urlPath || globalOptions.urlPath));
-    }
-    // cleanup before merging with global options
-    delete newOpts.dir;
+  if(opts.dir.imgSrc !== undefined) {
+    options.urlPath = opts.dir.imgSrc;
+    // set initial outputDir value (may be overwritten below)
+    options.outputDir = setOutputRootDir(opts.dir.imgSrc);
   }
 
-  return Object.assign({}, globalOptions, newOpts);
+  if(opts.dir.output !== undefined) {
+    // combine dir.output and dir.imgSrc into outputDir
+    options.outputDir = path.join(setOutputRootDir(opts.dir.output), (options.urlPath || globalOptions.urlPath));
+  }
+
+  // cleanup before merging with global options
+  delete options.dir;
+
+  return Object.assign({}, globalOptions, options);
 }
 
 async function queueImage(src, opts) {

--- a/img.js
+++ b/img.js
@@ -60,8 +60,9 @@ function getStats(src, format, urlPath, width, height, includeWidthInFilename) {
 		height: height,
 		// size // only after processing
 		// outputPath // only after processing
-		url: url,
+		url: url, // deprecate?
 		sourceType: MIME_TYPES[format],
+		src: url,
 		srcset: `${url} ${width}w`
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2,9 +2,9 @@ const test = require("ava");
 const eleventyImage = require("../");
 
 test("Sync with jpeg input", t => {
-	let stats = eleventyImage.statsSync("./test/bio-2017.jpg");
-	t.is(stats.webp.length, 1);
-	t.is(stats.jpeg.length, 1);
+  let stats = eleventyImage.statsSync("./test/bio-2017.jpg");
+  t.is(stats.webp.length, 1);
+  t.is(stats.jpeg.length, 1);
 });
 
 test("Sync by dimension with jpeg input", t => {
@@ -165,4 +165,41 @@ test("Use exact same width as original (statsSync)", t => {
 	t.is(stats.jpeg.length, 1);
 	t.is(stats.jpeg[0].url, "/img/97854483.jpeg"); // no width in filename
 	t.is(stats.jpeg[0].width, 1280);
+});
+
+test("Use a different output directory", async t => {
+	let stats = await eleventyImage("./test/bio-2017.jpg", {
+		formats: ["jpeg"],
+    dir: {
+      output: "sample/"
+    }
+	});
+	t.is(stats.jpeg.length, 1);
+	t.is(stats.jpeg[0].outputPath, "sample/img/97854483.jpeg");
+	t.is(stats.jpeg[0].src, "/img/97854483.jpeg");
+});
+
+test("Use a different img src directory", async t => {
+	let stats = await eleventyImage("./test/bio-2017.jpg", {
+		formats: ["jpeg"],
+    dir: {
+      imgSrc: "/images/"
+    }
+	});
+	t.is(stats.jpeg.length, 1);
+	t.is(stats.jpeg[0].outputPath, "images/97854483.jpeg");
+	t.is(stats.jpeg[0].src, "/images/97854483.jpeg");
+});
+
+test("Use a different img src and output directory", async t => {
+	let stats = await eleventyImage("./test/bio-2017.jpg", {
+		formats: ["jpeg"],
+    dir: {
+      imgSrc: "/images/",
+      output: "sample/"
+    }
+	});
+	t.is(stats.jpeg.length, 1);
+	t.is(stats.jpeg[0].outputPath, "sample/images/97854483.jpeg");
+	t.is(stats.jpeg[0].src, "/images/97854483.jpeg");
 });


### PR DESCRIPTION
First off, love this plugin! It quickly and easily pulls in my avatars from around the web, resizes them, and then caches them locally. So awesome!

The one thing that I found a bit confusing were the `urlPath` and `outputDir` options. It took me a bit of trial and error to realize what they were doing and it appears that others have had the same issue (see #7 and #9).

I'm proposing a non-breaking addition of a `dir` option borrowed from the `.eleventy.js` config file to hopefully clarify and perhaps improve the error handling.

* Add `options.dir.imgSrc` to represent the desired `<img src>` directory (see updated README and `test/test.js` for details/examples). This replaces `urlPath` in the options and gets merged into `urlPath` in the code (until deprecation makes sense).
* Add `options.dir.output` to represent the file system directory for image processing output. This replaces `outputDir` in the options and also represents just the output directory. The entire output path gets concatenated with the `imgSrc` value in the code and merged into the old `outputDir` behind the scenes (until deprecation makes sense).
* Add unit tests for the new options.

Separately, it also seems that `src`  makes more sense in the stats output than `url`. For example: `<img src="${props.src}" width="${props.width}" height="${props.height}" alt="${alt}">`. So I updated the code and README. 
* Add `src` as an alias of `url` (until it can be deprecated). 