### PR TITLE
Add option to allow customization of generated filenames for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Defaults values are shown:
   },
 
   cacheDuration: "1d", // deprecated, use cacheOptions above
+
+  // function to define custom filenames for the generated images
+  filenameFormat: function (id, src, width, format, options) {
+    // id: hash of the original image
+    // src: original image path
+    // width: current width in px
+    // format: current file format
+    // options: set of options passed to the Image call
+    if (width) {
+			return `${id}-${width}.${format}`;
+		}
+
+		return `${id}.${format}`;
+  }
 }
 ```
 
@@ -173,4 +187,33 @@ Use this object to generate your responsive image markup.
 ```js
 const Image = require("@11ty/eleventy-img");
 Image.concurrency = 4; // default is 10
+```
+
+### Generate custom filenames
+
+```js
+const path = require("path");
+const Image = require("@11ty/eleventy-img");
+
+let stats = await Image("./test/bio-2017.jpg", {
+  widths: [600, 1280],
+  formats: ["jpeg"],
+  outputDir: "./test/img/",
+  filenameFormat: function (id, src, width, format, options) {
+    const ext = path.extname(src)
+    const name = path.basename(src, ext)
+    
+    if (width) {
+      return `${name}-${id}-${width}.${format}`;
+    }
+
+    return `${name}-${id}.${format}`;
+  }
+});
+
+// stats.jpeg.length -> 2
+// stats.jpeg[0].outputPath -> "test/img/bio-2017-97854483-600.jpeg"
+// stats.jpeg[0].width -> 600
+// stats.jpeg[1].outputPath -> "test/img/bio-2017-97854483.jpeg"
+// stats.jpeg[1].width -> 1280
 ```

--- a/img.js
+++ b/img.js
@@ -65,8 +65,8 @@ function getFilename(src, width, format, options = {}) {
   return `${id}.${format}`;
 }
 
-function getStats(src, format, urlPath, width, height, includeWidthInFilename) {
-  let outputFilename = getFilename(src, includeWidthInFilename ? width : false, format);
+function getStats(src, format, urlPath, width, height, includeWidthInFilename, options = {}) {
+  let outputFilename = getFilename(src, includeWidthInFilename ? width : false, format, options);
   let url = path.join(urlPath, outputFilename);
 
   return {
@@ -157,7 +157,7 @@ async function resizeImage(src, options = {}) {
       let outputFilename = getFilename(src, width, format, options);
       let outputPath = path.join(options.outputDir, outputFilename);
       outputFilePromises.push(imageFormat.toFile(outputPath).then(data => {
-        let stats = getStats(src, format, options.urlPath, data.width, data.height, hasWidth);
+        let stats = getStats(src, format, options.urlPath, data.width, data.height, hasWidth, options);
         stats.outputPath = outputPath;
         stats.size = data.size;
 

--- a/img.js
+++ b/img.js
@@ -26,6 +26,13 @@ const globalOptions = {
 		// removeUrlQueryParams: false,
 		// fetchOptions: {},
 	},
+	filenameFormat: function (id, src, width, format, options) {
+		if (width) {
+			return `${id}-${width}.${format}`;
+		}
+
+		return `${id}.${format}`;
+	}
 };
 
 const MIME_TYPES = {
@@ -45,10 +52,13 @@ function getFormatsArray(formats) {
 	return [];
 }
 
-function getFilename(src, width, format) {
+function getFilename(src, width, format, options = {}) {
 	let id = shorthash(src);
+	if (typeof options.filenameFormat === 'function') {
+		return options.filenameFormat(id, src, width, format, options);
+	}
 
-	if(width) {
+	if (width) {
 		return `${id}-${width}.${format}`;
 	}
 
@@ -144,7 +154,7 @@ async function resizeImage(src, options = {}) {
 			}
 
 
-			let outputFilename = getFilename(src, width, format);
+			let outputFilename = getFilename(src, width, format, options);
 			let outputPath = path.join(options.outputDir, outputFilename);
 			outputFilePromises.push(imageFormat.toFile(outputPath).then(data => {
 				let stats = getStats(src, format, options.urlPath, data.width, data.height, hasWidth);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@11ty/eleventy-img",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Low level utility to perform build-time image transformations.",
   "publishConfig": {
     "access": "public"

--- a/test/test.js
+++ b/test/test.js
@@ -187,8 +187,12 @@ test("Use custom function to define file names", async (t) => {
   });
   t.is(stats.jpeg.length, 2);
   t.is(stats.jpeg[0].outputPath, "test/img/bio-2017-97854483-600.jpeg");
+  t.is(stats.jpeg[0].url, "/img/bio-2017-97854483-600.jpeg")
+  t.is(stats.jpeg[0].srcset, "/img/bio-2017-97854483-600.jpeg 600w");
   t.is(stats.jpeg[0].width, 600);
   t.is(stats.jpeg[1].outputPath, "test/img/bio-2017-97854483.jpeg");
+  t.is(stats.jpeg[1].url, "/img/bio-2017-97854483.jpeg");
+  t.is(stats.jpeg[1].srcset, "/img/bio-2017-97854483.jpeg 1280w");
   t.is(stats.jpeg[1].width, 1280);
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const test = require("ava");
 const eleventyImage = require("../");
 
@@ -166,3 +167,26 @@ test("Use exact same width as original (statsSync)", t => {
 	t.is(stats.jpeg[0].url, "/img/97854483.jpeg"); // no width in filename
 	t.is(stats.jpeg[0].width, 1280);
 });
+
+test("Use custom function to define file names", async (t) => {
+	let stats = await eleventyImage("./test/bio-2017.jpg", {
+		widths: [600, 1280],
+		formats: ["jpeg"],
+		outputDir: "./test/img/",
+		filenameFormat: function (id, src, width, format, options) {
+			const ext = path.extname(src)
+			const name = path.basename(src, ext)
+			
+			if (width) {
+				return `${name}-${id}-${width}.${format}`;
+			}
+	
+			return `${name}-${id}.${format}`;
+		}
+	});
+	t.is(stats.jpeg.length, 2);
+	t.is(stats.jpeg[0].outputPath, "test/img/bio-2017-97854483-600.jpeg");
+	t.is(stats.jpeg[0].width, 600);
+	t.is(stats.jpeg[1].outputPath, "test/img/bio-2017-97854483.jpeg");
+	t.is(stats.jpeg[1].width, 1280);
+})


### PR DESCRIPTION
This PR introduces a new configuration option called `filenameFormat` which can be used to change the default filename generation behaviour.

For instance, if you want the original filename to be included in the generated filename (e.g. for SEO reasons) you could do something like this:

```js
const path = require("path");
const Image = require("@11ty/eleventy-img");

let stats = await Image("./test/bio-2017.jpg", {
  widths: [600, 1280],
  formats: ["jpeg"],
  outputDir: "./test/img/",
  filenameFormat: function (id, src, width, format, options) {
    const ext = path.extname(src)
    const name = path.basename(src, ext)
    
    if (width) {
      return `${name}-${id}-${width}.${format}`;
    }

    return `${name}-${id}.${format}`;
  }
});

// stats.jpeg.length -> 2
// stats.jpeg[0].outputPath -> "test/img/bio-2017-97854483-600.jpeg"
// stats.jpeg[0].width -> 600
// stats.jpeg[1].outputPath -> "test/img/bio-2017-97854483.jpeg"
// stats.jpeg[1].width -> 1280
```

Note that the generated files will contain `bio-2017` which was the original filename.

README and tests have been updated accordingly