### PR TITLE
Docs: add urlPath/outputDir example, fix others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 test/img/
 sample/img/
+sample/images/
 sample/.cache/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Low level utility to perform build-time image transformations.
   * Keeps original image aspect ratios intact.
   * Never upscales images larger than original size.
 * Output multiple image formats.
-  * The [sharp](https://sharp.pixelplumbing.com/) image processor supports `jpeg`, `png`, `webp`, `raw`, and `tiff`.
+  * The [sharp](https://sharp.pixelplumbing.com/) image processor supports `jpeg`, `png`, and `webp`.
   * Incoming `gif` and `svg` images are converted to `png`.
 * Cache remote images locally using [eleventy-cache-assets](https://github.com/11ty/eleventy-cache-assets).
   * Use "local" images in your HTML to prevent broken image URLs.
@@ -51,13 +51,16 @@ Defaults values are shown:
   // widths: [200, null] // output 200px and original width
 
   // output image formats
-  formats: ["webp", "jpeg"], // also supported by sharp: "png", "raw", "tiff"
+  formats: ["webp", "jpeg"], // also supported by sharp: "png"
 
   // image directory for img element's src attribute (<img src="/img/MY_IMAGE.jpeg">)
   urlPath: "/img/",
 
   // project-relative path to the output image directory
   outputDir: "./img/",
+  // IMPORTANT: set urlPath and outputDir together, for example:
+  // urlPath: "/images/", outputDir: "./dist/images/"
+  // urlPath: "/img/", outputDir: "./dist/img/"
 
   // eleventy-cache-assets options (available in eleventy-img 0.3.0+)
   cacheOptions: {
@@ -75,20 +78,25 @@ Defaults values are shown:
 
 See all [relevant `eleventy-cache-assets` options in its documentation](https://github.com/11ty/eleventy-cache-assets/blob/master/README.md#options).
 
-## Examples
-
-### Output Optimized Images with Width/Height Attributes
-
-> Requires `async`, make sure you’re using this in Liquid, 11ty.js, or Nunjucks (use an async shortcode).
-
-#### Inputs for Optimized Images
+### Image Processing Concurrency
 
 ```js
-/* .eleventy.js */
+const Image = require("@11ty/eleventy-img");
+Image.concurrency = 4; // default is 10
+```
 
+## Examples
+
+> IMPORTANT: Use `async` shortcodes for [11ty.js](https://www.11ty.dev/docs/languages/javascript/#asynchronous-javascript-template-functions) and [Nunjucks](https://www.11ty.dev/docs/languages/nunjucks/#asynchronous-shortcodes) template engines ([Liquid](https://www.11ty.dev/docs/languages/liquid/#asynchronous-shortcodes) shortcodes are async by default).
+
+### Specifying Image Source and Output Directories
+
+#### Input for Specified Directories
+
+```js
 const Image = require("@11ty/eleventy-img");
 module.exports = function(eleventyConfig) {
-  // works also with addLiquidShortcode or addJavaScriptFunction
+  // works also with addLiquidShortcode or addJavascriptFunction
   eleventyConfig.addNunjucksAsyncShortcode("myImage", async function(src, alt, outputFormat = "jpeg") {
     if(alt === undefined) {
       // You bet we throw an error on missing alt (alt="" works okay)
@@ -97,10 +105,9 @@ module.exports = function(eleventyConfig) {
 
     // returns Promise
     let stats = await Image(src, {
-      widths: [50],
       formats: [outputFormat],
-      urlPath: "/images/",
-      outputDir: "./dist/images/",
+      urlPath: "/assets/img/",
+      outputDir: "./_site/assets/img/",
     });
 
     let props = stats[outputFormat].pop();
@@ -121,20 +128,87 @@ module.exports = function(eleventyConfig) {
 </div>
 ```
 
-#### Output for Optimized Images
+#### Output for Specified Directories
+
+```sh
+# project file system
+
+├─ .eleventy.js
+┊
+├─ _site
+│  ├─ assets
+│  │  ┊
+│  │  ├─ img
+│  │  │  ├─ 2311v21.jpeg
+│  │  │  └─ 3d00b40.jpeg
+┊  ┊  ┊
+```
 
 ```html
 <!-- dist/index.html -->
 
 <div>
-  <img src="/images/3d00b40-50.jpeg" width="50" height="50" alt="photo of my cat">
+  <img src="/assets/img/3d00b40.jpeg" width="1200" height="750" alt="photo of my cat">
 </div>
 <div>
-  <img src="/images/2311v21-50.jpeg" width="50" height="50" alt="photo of my dog">
+  <img src="/assets/img/2311v21.jpeg" width="1200" height="750" alt="photo of my dog">
 </div>
 ```
 
-### Output Optimized Multi-Format, Multi-Size Responsive Images using `<picture>`
+### Specify Output Width
+
+#### Inputs for Specified Width
+
+```js
+/* .eleventy.js */
+
+const Image = require("@11ty/eleventy-img");
+module.exports = function(eleventyConfig) {
+  // works also with addLiquidShortcode or addJavaScriptFunction
+  eleventyConfig.addNunjucksAsyncShortcode("myImage", async function(src, alt, outputFormat = "jpeg") {
+    if(alt === undefined) {
+      // You bet we throw an error on missing alt (alt="" works okay)
+      throw new Error(`Missing \`alt\` on myImage from: ${src}`);
+    }
+
+    // returns Promise
+    let stats = await Image(src, {
+      formats: [outputFormat],
+      widths: [600],
+    });
+
+    let props = stats[outputFormat].pop();
+
+    return `<img src="${props.url}" width="${props.width}" height="${props.height}" alt="${alt}">`;
+  });
+};
+```
+
+```html
+<!-- src/index.njk -->
+
+<div>
+  {% myImage "./src/images/cat.jpg", "photo of my cat" %}
+</div>
+<div>
+  {% myImage "https://my_site.com/assets/img/dog.jpg", "photo of my dog" %}
+</div>
+```
+
+#### Output for Specified Width
+
+```html
+<!-- dist/index.html -->
+
+<div>
+  <img src="/img/3d00b40-600.jpeg" width="600" height="375" alt="photo of my cat">
+</div>
+<div>
+  <img src="/img/2311v21-600.jpeg" width="600" height="375" alt="photo of my dog">
+</div>
+```
+
+### Specify Multi-Format, Multi-Size Responsive Images using `<picture>`
 
 #### Inputs for Responsive Images
 
@@ -144,31 +218,38 @@ module.exports = function(eleventyConfig) {
 const Image = require("@11ty/eleventy-img");
 module.exports = function(eleventyConfig) {
   // works also with addLiquidShortcode or addJavaScriptFunction
-  eleventyConfig.addNunjucksAsyncShortcode("myResponsiveImage", async function(src, alt, outputFormat = "jpeg") {
+  eleventyConfig.addNunjucksAsyncShortcode("myResponsiveImage", async function(src, alt, outputFormats = "jpeg") {
     if(alt === undefined) {
       // You bet we throw an error on missing alt (alt="" works okay)
       throw new Error(`Missing \`alt\` on myResponsiveImage from: ${src}`);
     }
 
-    let stats = await Image(src, {
-      widths: [null],
-      formats: [outputFormat],
-      urlPath: "/images/",
-      outputDir: "./dist/images/",
-    });
-    let lowestSrc = stats[outputFormat][0];
     let sizes = "100vw"; // Make sure you customize this!
+    // Note: the order of outputFormats matters, preferred formats should be listed first
+    let formats = outputFormats.split(",").map(txt => txt.trim());
+
+    let stats = await Image(src, {
+      formats,
+      widths: [400, 800, null],
+    });
+
+    const sourceBlock = Object.values(stats).map((imageFormat) => `<source
+      type="image/${imageFormat[0].format}"
+      srcset="${imageFormat.map((entry) => `${entry.url} ${entry.width}w`).join(', ')}"
+      sizes="${sizes}">`)
+      .join('\n');
+    // Default output format should be listed last
+    const defaultSrc = stats[formats.slice(-1)][0];
+    const imgBlock = `<img
+      src="${defaultSrc.url}"
+      width="${defaultSrc.width}"
+      height="${defaultSrc.height}"
+      alt="${alt}">`;
 
     // Iterate over formats and widths
     return `<picture>
-      ${Object.values(stats).map(imageFormat => {
-        return `  <source type="image/${imageFormat[0].format}" srcset="${imageFormat.map(entry => `${entry.url} ${entry.width}w`).join(", ")}" sizes="${sizes}">`;
-      }).join("\n")}
-        <img
-          src="${lowestSrc.url}"
-          width="${lowestSrc.width}"
-          height="${lowestSrc.height}"
-          alt="${alt}">
+        ${sourceBlock}
+        ${imgBlock}
       </picture>`;
     });
 };
@@ -178,10 +259,10 @@ module.exports = function(eleventyConfig) {
 <!-- index.njk -->
 
 <div>
-  {% myResponsiveImage "./src/images/cat.jpg", "photo of my cat"}
+  {% myResponsiveImage "./src/images/cat.jpg", "photo of my cat", "webp, jpeg" %}
 </div>
 <div>
-  {% myResponsiveImage "https://my_site.com/assets/img/dog.jpg", "photo of my dog" %}
+  {% myResponsiveImage "https://my_site.com/assets/img/dog.jpg", "photo of my dog", "webp, jpeg" %}
 </div>
 ```
 
@@ -192,14 +273,16 @@ module.exports = function(eleventyConfig) {
 
 <div>
   <picture>
-    <source type="image/jpeg" srcset="/images/3d00b40-96.jpeg 100w" sizes="100vw">
-    <img src="/images/3d00b40.jpeg" width="100" height="100" alt="photo of my cat">
+    <source type="image/jpeg" srcset="/img/3d00b40-400.jpeg 400w, /img/3d00b40-800.jpeg 800w, /img/3d00b40.jpeg 1200w" sizes="100vw">
+    <source type="image/webp" srcset="/img/3d00b40-400.webp 400w, /img/3d00b40-800.webp 800w, /img/3d00b40.webp 1200w" sizes="100vw">
+    <img src="/img/3d00b40-400.jpeg" width="400" height="250" alt="photo of my cat">
   </picture>
 </div>
 <div>
   <picture>
-    <source type="image/jpeg" srcset="/images/2311v21-75.jpeg 100w" sizes="100vw">
-    <img src="/images/2311v21.jpeg" width="100" height="100" alt="photo of my dog">
+    <source type="image/jpeg" srcset="/img/2311v21-400.jpeg 400w, /img/2311v21-800.jpeg 800w, /img/2311v21.jpeg 1200w" sizes="100vw">
+    <source type="image/webp" srcset="/img/2311v21-400.webp 400w, /img/2311v21-800.webp 800w, /img/2311v21.webp 1200w" sizes="100vw">
+    <img src="/img/2311v21-400.jpeg" width="400" height="250" alt="photo of my dog">
   </picture>
 </div>
 ```
@@ -209,45 +292,48 @@ module.exports = function(eleventyConfig) {
 Use this object to generate your responsive image markup.
 
 ```js
-{ webp:
-   [ { format: 'webp',
-       width: 1280,
-       height: 853,
-       url: '/img/9b186f9b.webp',
-       sourceType: 'image/webp',
-       srcset: '/img/9b186f9b.webp 1280w',
-       outputPath: 'img/9b186f9b.webp',
-       size: 213802 },
-     { format: 'webp',
-       width: 350,
-       height: 233,
-       url: '/img/9b186f9b-350.webp',
-       sourceType: 'image/webp',
-       srcset: '/img/9b186f9b-350.webp 350w',
-       outputPath: 'img/9b186f9b-350.webp',
-       size: 27288 } ],
-  jpeg:
-   [ { format: 'jpeg',
-       width: 1280,
-       height: 853,
-       url: '/img/9b186f9b.jpeg',
-       sourceType: 'image/jpg',
-       srcset: '/img/9b186f9b.jpeg 1280w',
-       outputPath: 'img/9b186f9b.jpeg',
-       size: 276231 },
-     { format: 'jpeg',
-       width: 350,
-       height: 233,
-       url: '/img/9b186f9b-350.jpeg',
-       sourceType: 'image/jpg',
-       srcset: '/img/9b186f9b-350.jpeg 350w',
-       outputPath: 'img/9b186f9b-350.jpeg',
-       size: 29101 } ] }
-```
-
-### Change Global Plugin Concurrency
-
-```js
-const Image = require("@11ty/eleventy-img");
-Image.concurrency = 4; // default is 10
+{
+  webp: [
+    {
+      format: 'webp',
+      width: 1280,
+      height: 853,
+      sourceType: 'image/webp',
+      url: '/img/9b186f9b.webp',
+      srcset: '/img/9b186f9b.webp 1280w',
+      outputPath: 'img/9b186f9b.webp',
+      size: 213802
+    }, {
+      format: 'webp',
+      width: 350,
+      height: 233,
+      sourceType: 'image/webp',
+      url: '/img/9b186f9b-350.webp',
+      srcset: '/img/9b186f9b-350.webp 350w',
+      outputPath: 'img/9b186f9b-350.webp',
+      size: 27288
+    }
+  ],
+  jpeg: [
+    {
+      format: 'jpeg',
+      width: 1280,
+      height: 853,
+      sourceType: 'image/jpg',
+      url: '/img/9b186f9b.jpeg',
+      srcset: '/img/9b186f9b.jpeg 1280w',
+      outputPath: 'img/9b186f9b.jpeg',
+      size: 276231
+    }, {
+      format: 'jpeg',
+      width: 350,
+      height: 233,
+      sourceType: 'image/jpg',
+      url: '/img/9b186f9b-350.jpeg',
+      srcset: '/img/9b186f9b-350.jpeg 350w',
+      outputPath: 'img/9b186f9b-350.jpeg',
+      size: 29101
+    }
+  ]
+}
 ```

--- a/README.md
+++ b/README.md
@@ -194,11 +194,13 @@ module.exports = function(eleventyConfig) {
   <picture>
     <source type="image/jpeg" srcset="/images/3d00b40-96.jpeg 100w" sizes="100vw">
     <img src="/images/3d00b40.jpeg" width="100" height="100" alt="photo of my cat">
+  </picture>
 </div>
 <div>
   <picture>
     <source type="image/jpeg" srcset="/images/2311v21-75.jpeg 100w" sizes="100vw">
     <img src="/images/2311v21.jpeg" width="100" height="100" alt="photo of my dog">
+  </picture>
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -295,43 +295,43 @@ Use this object to generate your responsive image markup.
 {
   webp: [
     {
-      format: 'webp',
+      format: "webp",
       width: 1280,
       height: 853,
-      sourceType: 'image/webp',
-      url: '/img/9b186f9b.webp',
-      srcset: '/img/9b186f9b.webp 1280w',
-      outputPath: 'img/9b186f9b.webp',
+      sourceType: "image/webp",
+      url: "/img/9b186f9b.webp",
+      srcset: "/img/9b186f9b.webp 1280w",
+      outputPath: "img/9b186f9b.webp",
       size: 213802
     }, {
-      format: 'webp',
+      format: "webp",
       width: 350,
       height: 233,
-      sourceType: 'image/webp',
-      url: '/img/9b186f9b-350.webp',
-      srcset: '/img/9b186f9b-350.webp 350w',
-      outputPath: 'img/9b186f9b-350.webp',
+      sourceType: "image/webp",
+      url: "/img/9b186f9b-350.webp",
+      srcset: "/img/9b186f9b-350.webp 350w",
+      outputPath: "img/9b186f9b-350.webp",
       size: 27288
     }
   ],
   jpeg: [
     {
-      format: 'jpeg',
+      format: "jpeg",
       width: 1280,
       height: 853,
-      sourceType: 'image/jpg',
-      url: '/img/9b186f9b.jpeg',
-      srcset: '/img/9b186f9b.jpeg 1280w',
-      outputPath: 'img/9b186f9b.jpeg',
+      sourceType: "image/jpg",
+      url: "/img/9b186f9b.jpeg",
+      srcset: "/img/9b186f9b.jpeg 1280w",
+      outputPath: "img/9b186f9b.jpeg",
       size: 276231
     }, {
-      format: 'jpeg',
+      format: "jpeg",
       width: 350,
       height: 233,
-      sourceType: 'image/jpg',
-      url: '/img/9b186f9b-350.jpeg',
-      srcset: '/img/9b186f9b-350.jpeg 350w',
-      outputPath: 'img/9b186f9b-350.jpeg',
+      sourceType: "image/jpg",
+      url: "/img/9b186f9b-350.jpeg",
+      srcset: "/img/9b186f9b-350.jpeg 350w",
+      outputPath: "img/9b186f9b-350.jpeg",
       size: 29101
     }
   ]

--- a/test/test.js
+++ b/test/test.js
@@ -182,11 +182,11 @@ test("Unavatar test", t => {
 });
 
 test("Set urlPath and outputDir", async t => {
-	let stats = await eleventyImage("./test/bio-2017.jpg", {
-		formats: ["jpeg"],
+  let stats = await eleventyImage("./test/bio-2017.jpg", {
+    formats: ["jpeg"],
     urlPath: "/images/",
     outputDir: "./sample/images/"
-	});
-	t.is(stats.jpeg[0].url, "/images/97854483.jpeg");
-	t.is(stats.jpeg[0].outputPath, "sample/images/97854483.jpeg");
+  });
+  t.is(stats.jpeg[0].url, "/images/97854483.jpeg");
+  t.is(stats.jpeg[0].outputPath, "sample/images/97854483.jpeg");
 });

--- a/test/test.js
+++ b/test/test.js
@@ -180,3 +180,13 @@ test("Unavatar test", t => {
   t.is(stats.jpeg[0].width, 75);
   t.is(stats.jpeg[0].height, 75);
 });
+
+test("Set urlPath and outputDir", async t => {
+	let stats = await eleventyImage("./test/bio-2017.jpg", {
+		formats: ["jpeg"],
+    urlPath: "/images/",
+    outputDir: "./sample/images/"
+	});
+	t.is(stats.jpeg[0].url, "/images/97854483.jpeg");
+	t.is(stats.jpeg[0].outputPath, "sample/images/97854483.jpeg");
+});


### PR DESCRIPTION
## Problem

1. It isn't immediately clear that `urlPath` and `outputDir` are co-dependent. You need to set them both at the same time and you need to close `outputDir` with the value of `urlPath`. This causes unnecessary confusion (ex: #7, #9).
2. I introduced some dimension and programmatic errors to the README examples in a recent PR (#18).
3. I recently added `raw` and `tiff` sharp formats (#18) to the README, but since realized the error of my ways. `sharp` does support `raw`, but to buffer only, and `tiff`, but browsers don't support it.

## Solution

README
1. Added detailed example for changing `urlPath` and `outputDir` settings.
2. Refined/corrected the other examples.
3. Corrected the `sharp` output formats.

TEST
* Added `urlPath`/`outputDir` test