### PR TITLE
Uptick sharp minor version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fs-extra": "^8.1.0",
     "image-size": "^0.8.3",
     "p-queue": "^6.3.0",
-    "sharp": "^0.25.2",
+    "sharp": "^0.26.2",
     "short-hash": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Solves [this error mentioned in the sharp repo](https://github.com/lovell/sharp/issues/2337):

```
dyld: lazy symbol binding failed: Symbol not found: _g_once_impl
```

if we try to use `sharp` elsewhere in our projects along with using this plugin. The current version of this plugin uses an older version of `sharp` uses a different version of libvips which conflicts with the latest. 

