### PR TITLE
Added reordering of formats

### DIFF
--- a/generate-html.js
+++ b/generate-html.js
@@ -12,6 +12,16 @@ function objectToAttributes(obj, filteredAttributes = []) {
   }).join(" ");
 }
 
+function reorderMetadataValues(data) {
+  const reordered = data.slice().sort((a, b) => LOWSRC_FORMAT_PREFERENCE.indexOf(b[0].format) - LOWSRC_FORMAT_PREFERENCE.indexOf(a[0].format));
+  const isChanged = JSON.stringify(data) !== JSON.stringify(reordered);
+  if (isChanged) {
+    const formatsOrder = arr => arr.map(x => x[0].format);
+    console.log(`Formats order was changed: from [${formatsOrder(data)}] to [${formatsOrder(reordered)}]`);
+  }
+  return reordered;
+} 
+
 function generateHTML(metadata, attributes = {}, options = {}) {
   attributes = Object.assign({}, DEFAULT_ATTRIBUTES, attributes);
 
@@ -74,9 +84,10 @@ function generateHTML(metadata, attributes = {}, options = {}) {
 
   let isInline = options.whitespaceMode !== "block";
   let markup = ["<picture>"];
-  values.filter(imageFormat => {
+  let filtered = values.filter(imageFormat => {
     return lowsrcFormat !== imageFormat[0].format || imageFormat.length !== 1;
-  }).forEach(imageFormat => {
+  });
+  reorderMetadataValues(filtered).forEach(imageFormat => {
     if(imageFormat.length > 1 && !attributes.sizes) {
       // Per the HTML specification sizes is required when multiple sources are in srcset
       // The default "100vw" is okay

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -50,6 +50,24 @@ test("Image markup (two formats)", async t => {
   }), `<picture><source type="image/avif" srcset="/img/97854483-1280.avif 1280w"><img alt="" src="/img/97854483-1280.webp" width="1280" height="853"></picture>`);
 });
 
+test("Image markup (three formats) with reorder", async t => {
+  let results = await eleventyImage("./test/bio-2017.jpg", {
+    dryRun: true,
+    formats: ["webp","jpeg", "avif"],
+  });
+
+  // print in console `Formats order was changed: from [webp,jpeg,avif] to [avif,webp,jpeg]`;
+  // Need test!!
+
+  t.is(generateHTML(results, {
+    alt: ""
+  }), [`<picture>`,
+    `<source type="image/avif" srcset="/img/97854483-1280.avif 1280w">`,
+    `<source type="image/webp" srcset="/img/97854483-1280.webp 1280w">`,
+    `<img alt="" src="/img/97854483-1280.jpeg" width="1280" height="853">`,
+    `</picture>`].join(""));
+});
+
 test("Image markup (one format)", async t => {
   let results = await eleventyImage("./test/bio-2017.jpg", {
     dryRun: true,


### PR DESCRIPTION
On #71, changes order of formats according to `LOWSRC_FORMAT_PREFERENCE` and prints the message.

If it's the appropriate way I need help -- I don't know how to test message in console using ava without sinon, for example.