### PR TITLE
Generate html improve error messages

### DIFF
--- a/generate-html.js
+++ b/generate-html.js
@@ -14,10 +14,12 @@ function objectToAttributes(obj, filteredAttributes = []) {
 
 function generateHTML(metadata, attributes = {}, options = {}) {
   attributes = Object.assign({}, DEFAULT_ATTRIBUTES, attributes);
+  // The attributes.src gets overwritten later on. Save it here to make the error outputs less cryptic.
+  const originalSrc = attributes.src;
 
   if(attributes.alt === undefined) {
     // You bet we throw an error on missing alt (alt="" works okay)
-    throw new Error(`Missing \`alt\` attribute on eleventy-img shortcode from: ${attributes.src}`);
+    throw new Error(`Missing \`alt\` attribute on eleventy-img shortcode from: ${originalSrc}`);
   }
 
   let formats = Object.keys(metadata);
@@ -42,7 +44,7 @@ function generateHTML(metadata, attributes = {}, options = {}) {
   }
 
   if(!lowsrc || !lowsrc.length) {
-    throw new Error(`Could not find the lowest <img> source for responsive markup for ${attributes.src}`);
+    throw new Error(`Could not find the lowest <img> source for responsive markup for ${originalSrc}`);
   }
 
   attributes.src = lowsrc[0].url;
@@ -58,7 +60,7 @@ function generateHTML(metadata, attributes = {}, options = {}) {
   }
 
   let sizesAttr = attributes.sizes ? ` sizes="${attributes.sizes}"` : "";
-  let missingSizesErrorMessage = `Missing \`sizes\` attribute on eleventy-img shortcode from: ${attributes.src}`;
+  let missingSizesErrorMessage = `Missing \`sizes\` attribute on eleventy-img shortcode from: ${originalSrc || attributes.src}`;
 
   // <img srcset>: one format and multiple sizes
   if(formats.length === 1) { // implied entryCount > 1

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -82,6 +82,14 @@ test("Image markup (throws on invalid object)", async t => {
   t.notThrows(() => generateHTML({ jpeg: [{}] }, { alt: "" }));
 });
 
+test("Image markup (throws on missing alt)", async t => {
+  let results = await eleventyImage("./test/bio-2017.jpg", {
+    dryRun: true
+  });
+
+  t.throws(() => generateHTML(results, {}));
+});
+
 test("Image markup (defaults, inlined)", async t => {
   let results = await eleventyImage("./test/bio-2017.jpg", {
     dryRun: true


### PR DESCRIPTION
Currently the error messages for missing sizes only contain the output src from sharp as a reference.

This PR always makes an best effort to print the original src and falls back to the output src of no original one was provided.

It also adds a test for missing alt attributes to throw an error (like documented).