### PR TITLE
Prevent images from being rotated if the original contains EXIF orientation metadata

### DIFF
--- a/img.js
+++ b/img.js
@@ -292,6 +292,7 @@ async function resizeImage(src, options = {}) {
         if(metadata.format !== "svg" || !options.svgAllowUpscale) {
           resizeOptions.withoutEnlargement = true;
         }
+        sharpInstance.rotate();
         sharpInstance.resize(resizeOptions);
       }
 


### PR DESCRIPTION
Fixes: #49

Adds a rotation operation using sharp immediately prior to resizing, as suggested in Stack Overflow post [here](https://stackoverflow.com/questions/48716266/sharp-image-library-rotates-image-when-resizing).