### PR TITLE
Persist in-memory cache, change hash.

### DIFF
--- a/img.js
+++ b/img.js
@@ -126,7 +126,11 @@ function getValidWidths(originalWidth, widths = [], allowUpscale = false) {
 let imgHashCache = {};
 function getHash(src, imgOptions={}, length=10) {
   if(src in imgHashCache) return imgHashCache[src];
-  
+
+  if(typeof src === "string" && isFullUrl(src) && !("remoteAssetContent" in imgOptions)) {
+    throw new Error("When using getHash with URLs, imgOptions.remoteAssetContent should be set to the content of the remote asset.");
+  }
+
   const hash = createHash("sha256");
 
   let opts = Object.assign({
@@ -478,17 +482,19 @@ Object.defineProperty(module.exports, "concurrency", {
  * the correct location yet.
  */
 function statsSync(src, opts) {
-  if(typeof src === "string" && isFullUrl(src) && !('remoteAssetContent' in opts)) {
-    throw new Error("When using statsSync or statsByDimensionsSync with URLs, opts.remoteAssetContent should be set to the content of the remote asset.");
+  if(typeof src === "string" && isFullUrl(src) && !("remoteAssetContent" in opts)) {
+    throw new Error("When using statsSync or statsByDimensionsSync with URLs, options.remoteAssetContent should be set to the content of the remote asset.");
   }
+
   let dimensions = getImageSize(src);
   return getFullStats(src, dimensions, opts);
 }
 
 function statsByDimensionsSync(src, width, height, opts) {
-  if(typeof src === "string" && isFullUrl(src) && !('remoteAssetContent' in opts)) {
-    throw new Error("When using statsSync or statsByDimensionsSync with URLs, opts.remoteAssetContent should be set to the content of the remote asset.");
+  if(typeof src === "string" && isFullUrl(src) && !("remoteAssetContent" in opts)) {
+    throw new Error("When using statsSync or statsByDimensionsSync with URLs, options.remoteAssetContent should be set to the content of the remote asset.");
   }
+
   let dimensions = { width, height, guess: true };
   return getFullStats(src, dimensions, opts);
 }

--- a/img.js
+++ b/img.js
@@ -309,7 +309,12 @@ async function resizeImage(src, options = {}) {
   let fullStats = getFullStats(src, metadata, options);
   for(let outputFormat in fullStats) {
     for(let stat of fullStats[outputFormat]) {
-      if(options.useCache && !options.svgShortCircuit && fs.existsSync(stat.outputPath)){
+      if(options.useCache && fs.existsSync(stat.outputPath)){
+        stat.size = fs.statSync(stat.outputPath).size;
+        if(options.dryRun) {
+          stat.buffer = fs.readFileSync(src);
+        }
+
         outputFilePromises.push(Promise.resolve(stat));
         continue;
       }

--- a/img.js
+++ b/img.js
@@ -122,15 +122,25 @@ function getValidWidths(originalWidth, widths = [], allowUpscale = false) {
   return filtered.sort((a, b) => a - b);
 }
 
-function getFileHash(src, options) {
-  const hash = createHash("sha1");
+function getHash(src, imgOptions={}, length=10) {
+  const hash = createHash("sha256");
 
-  const opts = {
-    sharpOptions: options.sharpOptions,
-    sharpWebpOptions: options.sharpWebpOptions,
-    sharpPngOptions: options.sharpPngOptions,
-    sharpJpegOptions: options.sharpJpegOptions,
-    sharpAvifOptions: options.sharpAvifOptions
+  let opts = Object.assign({
+    "userOptions": {},
+    "sharpOptions": {}, 
+    "sharpWebpOptions": {},
+    "sharpPngOptions": {},
+    "sharpJpegOptions": {},
+    "sharpAvifOptions": {},
+  }, imgOptions);
+
+  opts = {
+    userOptions: opts.userOptions,
+    sharpOptions: opts.sharpOptions,
+    sharpWebpOptions: opts.sharpWebpOptions,
+    sharpPngOptions: opts.sharpPngOptions,
+    sharpJpegOptions: opts.sharpJpegOptions,
+    sharpAvifOptions: opts.sharpAvifOptions,
   };
 
   if(fs.existsSync(src)) {
@@ -141,12 +151,11 @@ function getFileHash(src, options) {
   }
 
   hash.update(JSON.stringify(opts));
-
-  return hash.digest('hex').substring(0, 8);
+  return hash.digest("base64url").substring(0, length);;
 }
 
 function getFilename(src, width, format, options = {}) {
-  let id = getFileHash(src, options);
+  let id = getHash(src, options);
 
   if (typeof options.filenameFormat === "function") {
     let filename = options.filenameFormat(id, src, width, format, options);
@@ -170,7 +179,7 @@ function getStats(src, format, urlPath, width, height, options = {}) {
   let outputExtension = options.extensions[format] || format;
 
   if(options.urlFormat && typeof options.urlFormat === "function") {
-    let id = getFileHash(src, options);
+    let id = getHash(src, options);
 
     url = options.urlFormat({
       id,
@@ -472,6 +481,7 @@ module.exports.statsSync = statsSync;
 module.exports.statsByDimensionsSync = statsByDimensionsSync;
 module.exports.getFormats = getFormatsArray;
 module.exports.getWidths = getValidWidths;
+module.exports.getHash = getHash;
 
 const generateHTML = require("./generate-html");
 module.exports.generateHTML = generateHTML;

--- a/img.js
+++ b/img.js
@@ -3,6 +3,7 @@ const { createHash } = require("crypto");
 const fs = require("fs-extra");
 const { URL } = require("url");
 const {default: PQueue} = require("p-queue");
+const base64url = require("base64url");
 const getImageSize = require("image-size");
 const sharp = require("sharp");
 const debug = require("debug")("EleventyImg");
@@ -154,7 +155,7 @@ function getHash(src, imgOptions={}, length=10) {
   }
 
   hash.update(JSON.stringify(opts));
-  imgHashCache[src] = hash.digest("base64url").substring(0, length);
+  imgHashCache[src] = base64url.encode(hash.digest()).substring(0, length);
 
   return imgHashCache[src];
 }

--- a/img.js
+++ b/img.js
@@ -122,7 +122,10 @@ function getValidWidths(originalWidth, widths = [], allowUpscale = false) {
   return filtered.sort((a, b) => a - b);
 }
 
+let imgHashCache = {};
 function getHash(src, imgOptions={}, length=10) {
+  if(src in imgHashCache) return imgHashCache[src];
+  
   const hash = createHash("sha256");
 
   let opts = Object.assign({
@@ -151,7 +154,9 @@ function getHash(src, imgOptions={}, length=10) {
   }
 
   hash.update(JSON.stringify(opts));
-  return hash.digest("base64url").substring(0, length);;
+  imgHashCache[src] = hash.digest("base64url").substring(0, length);
+
+  return imgHashCache[src];
 }
 
 function getFilename(src, width, format, options = {}) {

--- a/img.js
+++ b/img.js
@@ -136,6 +136,7 @@ function getHash(src, imgOptions={}, length=10) {
     "sharpPngOptions": {},
     "sharpJpegOptions": {},
     "sharpAvifOptions": {},
+    "remoteAssetContent": {}
   }, imgOptions);
 
   opts = {
@@ -145,6 +146,7 @@ function getHash(src, imgOptions={}, length=10) {
     sharpPngOptions: opts.sharpPngOptions,
     sharpJpegOptions: opts.sharpJpegOptions,
     sharpAvifOptions: opts.sharpAvifOptions,
+    remoteAssetContent: opts.remoteAssetContent
   };
 
   if(fs.existsSync(src)) {
@@ -444,6 +446,8 @@ function queueImage(src, opts) {
         // eleventy-cache-assets 2.0.3 and below
         input = await assetCache.fetch(cacheOptions);
       }
+
+      options.remoteAssetContent = input; // Only set for remote assets with URL
     } else {
       input = src;
     }
@@ -474,11 +478,17 @@ Object.defineProperty(module.exports, "concurrency", {
  * the correct location yet.
  */
 function statsSync(src, opts) {
+  if(typeof src === "string" && isFullUrl(src) && !('remoteAssetContent' in opts)) {
+    throw new Error("When using statsSync or statsByDimensionsSync with URLs, opts.remoteAssetContent should be set to the content of the remote asset.");
+  }
   let dimensions = getImageSize(src);
   return getFullStats(src, dimensions, opts);
 }
 
 function statsByDimensionsSync(src, width, height, opts) {
+  if(typeof src === "string" && isFullUrl(src) && !('remoteAssetContent' in opts)) {
+    throw new Error("When using statsSync or statsByDimensionsSync with URLs, opts.remoteAssetContent should be set to the content of the remote asset.");
+  }
   let dimensions = { width, height, guess: true };
   return getFullStats(src, dimensions, opts);
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/11ty/eleventy-img#readme",
   "dependencies": {
     "@11ty/eleventy-cache-assets": "^2.2.1",
+    "base64url": "^3.0.1",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.1",
     "image-size": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "fs-extra": "^9.0.1",
     "image-size": "^0.9.3",
     "p-queue": "^6.6.2",
-    "sharp": "^0.28.2",
-    "short-hash": "^1.0.0"
+    "sharp": "^0.28.2"
   },
   "devDependencies": {
     "ava": "^3.15.0",

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -10,7 +10,7 @@ test("Image markup (defaults)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/webp" srcset="/img/70DaY9n7K_-1280.webp 1280w"><img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/webp" srcset="/img/Bok0Qhed6a-1280.webp 1280w"><img alt="" src="/img/Bok0Qhed6a-1280.jpeg" width="1280" height="853"></picture>`);
 });
 
 test("Image service", async t => {
@@ -23,7 +23,8 @@ test("Image service", async t => {
     widths: [600], // 260-440 in layout
     urlFormat: function({ width, format }) {
       return `${serviceApiDomain}/api/image/?url=${encodeURIComponent(screenshotUrl)}&width=${width}&format=${format}`;
-    }
+    },
+    remoteAssetContent: 'remote asset content'
   };
 
   let results = eleventyImage.statsByDimensionsSync(screenshotUrl, 1440, 900, options);
@@ -45,13 +46,13 @@ test("Image object (defaults)", async t => {
       {
         "source": {
           type: "image/webp",
-          srcset: "/img/70DaY9n7K_-1280.webp 1280w",
+          srcset: "/img/Bok0Qhed6a-1280.webp 1280w",
         }
       },
       {
         "img": {
           alt: "",
-          src: "/img/70DaY9n7K_-1280.jpeg",
+          src: "/img/Bok0Qhed6a-1280.jpeg",
           width: 1280,
           height: 853,
         }
@@ -70,9 +71,9 @@ test("Image markup (two widths)", async t => {
     alt: "",
     sizes: "100vw",
   }), [`<picture>`,
-    `<source type="image/webp" srcset="/img/70DaY9n7K_-200.webp 200w, /img/70DaY9n7K_-400.webp 400w" sizes="100vw">`,
-    `<source type="image/jpeg" srcset="/img/70DaY9n7K_-200.jpeg 200w, /img/70DaY9n7K_-400.jpeg 400w" sizes="100vw">`,
-    `<img alt="" src="/img/70DaY9n7K_-200.jpeg" width="400" height="266">`,
+    `<source type="image/webp" srcset="/img/Bok0Qhed6a-200.webp 200w, /img/Bok0Qhed6a-400.webp 400w" sizes="100vw">`,
+    `<source type="image/jpeg" srcset="/img/Bok0Qhed6a-200.jpeg 200w, /img/Bok0Qhed6a-400.jpeg 400w" sizes="100vw">`,
+    `<img alt="" src="/img/Bok0Qhed6a-200.jpeg" width="400" height="266">`,
     `</picture>`].join(""));
 });
 
@@ -95,7 +96,7 @@ test("Image markup (two formats)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/avif" srcset="/img/70DaY9n7K_-1280.avif 1280w"><img alt="" src="/img/70DaY9n7K_-1280.webp" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/avif" srcset="/img/Bok0Qhed6a-1280.avif 1280w"><img alt="" src="/img/Bok0Qhed6a-1280.webp" width="1280" height="853"></picture>`);
 });
 
 test("Image markup (one format)", async t => {
@@ -107,7 +108,7 @@ test("Image markup (one format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/Bok0Qhed6a-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (auto format)", async t => {
@@ -119,7 +120,7 @@ test("Image markup (auto format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/Bok0Qhed6a-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (one format, two widths)", async t => {
@@ -132,7 +133,7 @@ test("Image markup (one format, two widths)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/70DaY9n7K_-100.jpeg" width="200" height="133" srcset="/img/70DaY9n7K_-100.jpeg 100w, /img/70DaY9n7K_-200.jpeg 200w" sizes="100vw">`);
+  }), `<img alt="" src="/img/Bok0Qhed6a-100.jpeg" width="200" height="133" srcset="/img/Bok0Qhed6a-100.jpeg 100w, /img/Bok0Qhed6a-200.jpeg 200w" sizes="100vw">`);
 });
 
 test("Image markup (throws on invalid object)", async t => {
@@ -160,8 +161,8 @@ test("Image markup (defaults, inlined)", async t => {
   }, {
     whitespaceMode: "block"
   }), `<picture>
-  <source type="image/webp" srcset="/img/70DaY9n7K_-1280.webp 1280w">
-  <img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">
+  <source type="image/webp" srcset="/img/Bok0Qhed6a-1280.webp 1280w">
+  <img alt="" src="/img/Bok0Qhed6a-1280.jpeg" width="1280" height="853">
 </picture>`);
 });
 
@@ -175,7 +176,7 @@ test("svgShortCircuit and generateHTML: Issue #48", async t => {
   let html = eleventyImage.generateHTML(stats, {
     alt: "Tiger",
   });
-  t.is(html, `<img alt="Tiger" src="/img/UqY06ReSxc-900.svg" width="900" height="900">`);
+  t.is(html, `<img alt="Tiger" src="/img/VBWwBwQG9D-900.svg" width="900" height="900">`);
 });
 
 test("Filter out empty format arrays", async t => {

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -10,7 +10,7 @@ test("Image markup (defaults)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/webp" srcset="/img/a705425c-1280.webp 1280w"><img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/webp" srcset="/img/e1d4b79f-1280.webp 1280w"><img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853"></picture>`);
 });
 
 test("Image service", async t => {
@@ -45,13 +45,13 @@ test("Image object (defaults)", async t => {
       {
         "source": {
           type: "image/webp",
-          srcset: "/img/a705425c-1280.webp 1280w",
+          srcset: "/img/e1d4b79f-1280.webp 1280w",
         }
       },
       {
         "img": {
           alt: "",
-          src: "/img/a705425c-1280.jpeg",
+          src: "/img/e1d4b79f-1280.jpeg",
           width: 1280,
           height: 853,
         }
@@ -70,9 +70,9 @@ test("Image markup (two widths)", async t => {
     alt: "",
     sizes: "100vw",
   }), [`<picture>`,
-    `<source type="image/webp" srcset="/img/a705425c-200.webp 200w, /img/a705425c-400.webp 400w" sizes="100vw">`,
-    `<source type="image/jpeg" srcset="/img/a705425c-200.jpeg 200w, /img/a705425c-400.jpeg 400w" sizes="100vw">`,
-    `<img alt="" src="/img/a705425c-200.jpeg" width="400" height="266">`,
+    `<source type="image/webp" srcset="/img/e1d4b79f-200.webp 200w, /img/e1d4b79f-400.webp 400w" sizes="100vw">`,
+    `<source type="image/jpeg" srcset="/img/e1d4b79f-200.jpeg 200w, /img/e1d4b79f-400.jpeg 400w" sizes="100vw">`,
+    `<img alt="" src="/img/e1d4b79f-200.jpeg" width="400" height="266">`,
     `</picture>`].join(""));
 });
 
@@ -95,7 +95,7 @@ test("Image markup (two formats)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/avif" srcset="/img/a705425c-1280.avif 1280w"><img alt="" src="/img/a705425c-1280.webp" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/avif" srcset="/img/e1d4b79f-1280.avif 1280w"><img alt="" src="/img/e1d4b79f-1280.webp" width="1280" height="853"></picture>`);
 });
 
 test("Image markup (one format)", async t => {
@@ -107,7 +107,7 @@ test("Image markup (one format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (auto format)", async t => {
@@ -119,7 +119,7 @@ test("Image markup (auto format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (one format, two widths)", async t => {
@@ -132,7 +132,7 @@ test("Image markup (one format, two widths)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/a705425c-100.jpeg" width="200" height="133" srcset="/img/a705425c-100.jpeg 100w, /img/a705425c-200.jpeg 200w" sizes="100vw">`);
+  }), `<img alt="" src="/img/e1d4b79f-100.jpeg" width="200" height="133" srcset="/img/e1d4b79f-100.jpeg 100w, /img/e1d4b79f-200.jpeg 200w" sizes="100vw">`);
 });
 
 test("Image markup (throws on invalid object)", async t => {
@@ -160,8 +160,8 @@ test("Image markup (defaults, inlined)", async t => {
   }, {
     whitespaceMode: "block"
   }), `<picture>
-  <source type="image/webp" srcset="/img/a705425c-1280.webp 1280w">
-  <img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">
+  <source type="image/webp" srcset="/img/e1d4b79f-1280.webp 1280w">
+  <img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">
 </picture>`);
 });
 
@@ -175,7 +175,7 @@ test("svgShortCircuit and generateHTML: Issue #48", async t => {
   let html = eleventyImage.generateHTML(stats, {
     alt: "Tiger",
   });
-  t.is(html, `<img alt="Tiger" src="/img/a705425c-900.svg" width="900" height="900">`);
+  t.is(html, `<img alt="Tiger" src="/img/fc94394f-900.svg" width="900" height="900">`);
 });
 
 test("Filter out empty format arrays", async t => {

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -10,7 +10,7 @@ test("Image markup (defaults)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/webp" srcset="/img/97854483-1280.webp 1280w"><img alt="" src="/img/97854483-1280.jpeg" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/webp" srcset="/img/a705425c-1280.webp 1280w"><img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853"></picture>`);
 });
 
 test("Image service", async t => {
@@ -45,13 +45,13 @@ test("Image object (defaults)", async t => {
       {
         "source": {
           type: "image/webp",
-          srcset: "/img/97854483-1280.webp 1280w",
+          srcset: "/img/a705425c-1280.webp 1280w",
         }
       },
       {
         "img": {
           alt: "",
-          src: "/img/97854483-1280.jpeg",
+          src: "/img/a705425c-1280.jpeg",
           width: 1280,
           height: 853,
         }
@@ -70,9 +70,9 @@ test("Image markup (two widths)", async t => {
     alt: "",
     sizes: "100vw",
   }), [`<picture>`,
-    `<source type="image/webp" srcset="/img/97854483-200.webp 200w, /img/97854483-400.webp 400w" sizes="100vw">`,
-    `<source type="image/jpeg" srcset="/img/97854483-200.jpeg 200w, /img/97854483-400.jpeg 400w" sizes="100vw">`,
-    `<img alt="" src="/img/97854483-200.jpeg" width="400" height="266">`,
+    `<source type="image/webp" srcset="/img/a705425c-200.webp 200w, /img/a705425c-400.webp 400w" sizes="100vw">`,
+    `<source type="image/jpeg" srcset="/img/a705425c-200.jpeg 200w, /img/a705425c-400.jpeg 400w" sizes="100vw">`,
+    `<img alt="" src="/img/a705425c-200.jpeg" width="400" height="266">`,
     `</picture>`].join(""));
 });
 
@@ -95,7 +95,7 @@ test("Image markup (two formats)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/avif" srcset="/img/97854483-1280.avif 1280w"><img alt="" src="/img/97854483-1280.webp" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/avif" srcset="/img/a705425c-1280.avif 1280w"><img alt="" src="/img/a705425c-1280.webp" width="1280" height="853"></picture>`);
 });
 
 test("Image markup (one format)", async t => {
@@ -107,7 +107,7 @@ test("Image markup (one format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/97854483-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (auto format)", async t => {
@@ -119,7 +119,7 @@ test("Image markup (auto format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/97854483-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (one format, two widths)", async t => {
@@ -132,7 +132,7 @@ test("Image markup (one format, two widths)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/97854483-100.jpeg" width="200" height="133" srcset="/img/97854483-100.jpeg 100w, /img/97854483-200.jpeg 200w" sizes="100vw">`);
+  }), `<img alt="" src="/img/a705425c-100.jpeg" width="200" height="133" srcset="/img/a705425c-100.jpeg 100w, /img/a705425c-200.jpeg 200w" sizes="100vw">`);
 });
 
 test("Image markup (throws on invalid object)", async t => {
@@ -160,8 +160,8 @@ test("Image markup (defaults, inlined)", async t => {
   }, {
     whitespaceMode: "block"
   }), `<picture>
-  <source type="image/webp" srcset="/img/97854483-1280.webp 1280w">
-  <img alt="" src="/img/97854483-1280.jpeg" width="1280" height="853">
+  <source type="image/webp" srcset="/img/a705425c-1280.webp 1280w">
+  <img alt="" src="/img/a705425c-1280.jpeg" width="1280" height="853">
 </picture>`);
 });
 
@@ -175,7 +175,7 @@ test("svgShortCircuit and generateHTML: Issue #48", async t => {
   let html = eleventyImage.generateHTML(stats, {
     alt: "Tiger",
   });
-  t.is(html, `<img alt="Tiger" src="/img/8b4d670b-900.svg" width="900" height="900">`);
+  t.is(html, `<img alt="Tiger" src="/img/a705425c-900.svg" width="900" height="900">`);
 });
 
 test("Filter out empty format arrays", async t => {

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -10,7 +10,7 @@ test("Image markup (defaults)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/webp" srcset="/img/e1d4b79f-1280.webp 1280w"><img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/webp" srcset="/img/70DaY9n7K_-1280.webp 1280w"><img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853"></picture>`);
 });
 
 test("Image service", async t => {
@@ -45,13 +45,13 @@ test("Image object (defaults)", async t => {
       {
         "source": {
           type: "image/webp",
-          srcset: "/img/e1d4b79f-1280.webp 1280w",
+          srcset: "/img/70DaY9n7K_-1280.webp 1280w",
         }
       },
       {
         "img": {
           alt: "",
-          src: "/img/e1d4b79f-1280.jpeg",
+          src: "/img/70DaY9n7K_-1280.jpeg",
           width: 1280,
           height: 853,
         }
@@ -70,9 +70,9 @@ test("Image markup (two widths)", async t => {
     alt: "",
     sizes: "100vw",
   }), [`<picture>`,
-    `<source type="image/webp" srcset="/img/e1d4b79f-200.webp 200w, /img/e1d4b79f-400.webp 400w" sizes="100vw">`,
-    `<source type="image/jpeg" srcset="/img/e1d4b79f-200.jpeg 200w, /img/e1d4b79f-400.jpeg 400w" sizes="100vw">`,
-    `<img alt="" src="/img/e1d4b79f-200.jpeg" width="400" height="266">`,
+    `<source type="image/webp" srcset="/img/70DaY9n7K_-200.webp 200w, /img/70DaY9n7K_-400.webp 400w" sizes="100vw">`,
+    `<source type="image/jpeg" srcset="/img/70DaY9n7K_-200.jpeg 200w, /img/70DaY9n7K_-400.jpeg 400w" sizes="100vw">`,
+    `<img alt="" src="/img/70DaY9n7K_-200.jpeg" width="400" height="266">`,
     `</picture>`].join(""));
 });
 
@@ -95,7 +95,7 @@ test("Image markup (two formats)", async t => {
 
   t.is(generateHTML(results, {
     alt: ""
-  }), `<picture><source type="image/avif" srcset="/img/e1d4b79f-1280.avif 1280w"><img alt="" src="/img/e1d4b79f-1280.webp" width="1280" height="853"></picture>`);
+  }), `<picture><source type="image/avif" srcset="/img/70DaY9n7K_-1280.avif 1280w"><img alt="" src="/img/70DaY9n7K_-1280.webp" width="1280" height="853"></picture>`);
 });
 
 test("Image markup (one format)", async t => {
@@ -107,7 +107,7 @@ test("Image markup (one format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (auto format)", async t => {
@@ -119,7 +119,7 @@ test("Image markup (auto format)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">`);
+  }), `<img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">`);
 });
 
 test("Image markup (one format, two widths)", async t => {
@@ -132,7 +132,7 @@ test("Image markup (one format, two widths)", async t => {
   t.is(generateHTML(results, {
     alt: "",
     sizes: "100vw"
-  }), `<img alt="" src="/img/e1d4b79f-100.jpeg" width="200" height="133" srcset="/img/e1d4b79f-100.jpeg 100w, /img/e1d4b79f-200.jpeg 200w" sizes="100vw">`);
+  }), `<img alt="" src="/img/70DaY9n7K_-100.jpeg" width="200" height="133" srcset="/img/70DaY9n7K_-100.jpeg 100w, /img/70DaY9n7K_-200.jpeg 200w" sizes="100vw">`);
 });
 
 test("Image markup (throws on invalid object)", async t => {
@@ -160,8 +160,8 @@ test("Image markup (defaults, inlined)", async t => {
   }, {
     whitespaceMode: "block"
   }), `<picture>
-  <source type="image/webp" srcset="/img/e1d4b79f-1280.webp 1280w">
-  <img alt="" src="/img/e1d4b79f-1280.jpeg" width="1280" height="853">
+  <source type="image/webp" srcset="/img/70DaY9n7K_-1280.webp 1280w">
+  <img alt="" src="/img/70DaY9n7K_-1280.jpeg" width="1280" height="853">
 </picture>`);
 });
 
@@ -175,7 +175,7 @@ test("svgShortCircuit and generateHTML: Issue #48", async t => {
   let html = eleventyImage.generateHTML(stats, {
     alt: "Tiger",
   });
-  t.is(html, `<img alt="Tiger" src="/img/fc94394f-900.svg" width="900" height="900">`);
+  t.is(html, `<img alt="Tiger" src="/img/UqY06ReSxc-900.svg" width="900" height="900">`);
 });
 
 test("Filter out empty format arrays", async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ test("Use 'auto' format as original", async t => {
 
   t.is(stats.auto, undefined);
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -181,7 +181,7 @@ test("Try to use a width larger than original", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -192,7 +192,7 @@ test("Try to use a width larger than original (two sizes)", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -203,7 +203,7 @@ test("Try to use a width larger than original (with a null in there)", async t =
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -214,7 +214,7 @@ test("Just falsy width", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -226,7 +226,7 @@ test("Use exact same width as original", async t => {
   });
   t.is(stats.jpeg.length, 1);
   // breaking change in 0.5: always use width in filename
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/97854483-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -237,7 +237,7 @@ test("Try to use a width larger than original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/97854483-1280.jpeg");
+  t.is(stats.jpeg[0].url, "/img/a705425c-1280.jpeg");
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -248,7 +248,7 @@ test("Use exact same width as original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/97854483-1280.jpeg"); // no width in filename
+  t.is(stats.jpeg[0].url, "/img/a705425c-1280.jpeg"); // no width in filename
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -270,13 +270,13 @@ test("Use custom function to define file names", async (t) => {
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-97854483-600.jpeg"));
-  t.is(stats.jpeg[0].url, "/img/bio-2017-97854483-600.jpeg");
-  t.is(stats.jpeg[0].srcset, "/img/bio-2017-97854483-600.jpeg 600w");
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-a705425c-600.jpeg"));
+  t.is(stats.jpeg[0].url, "/img/bio-2017-a705425c-600.jpeg");
+  t.is(stats.jpeg[0].srcset, "/img/bio-2017-a705425c-600.jpeg 600w");
   t.is(stats.jpeg[0].width, 600);
-  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-97854483-1280.jpeg"));
-  t.is(stats.jpeg[1].url, "/img/bio-2017-97854483-1280.jpeg");
-  t.is(stats.jpeg[1].srcset, "/img/bio-2017-97854483-1280.jpeg 1280w");
+  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-a705425c-1280.jpeg"));
+  t.is(stats.jpeg[1].url, "/img/bio-2017-a705425c-1280.jpeg");
+  t.is(stats.jpeg[1].srcset, "/img/bio-2017-a705425c-1280.jpeg 1280w");
   t.is(stats.jpeg[1].width, 1280);
 });
 
@@ -386,7 +386,7 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are smaller 
 
   // this won’t upscale so it will miss out on higher resolution images but there won’t be any broken image URLs in the output
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("img/97854483-164.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/a705425c-164.jpeg"));
 });
 
 test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger than real)", t => {
@@ -396,8 +396,8 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger t
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("img/97854483-164.jpeg"));
-  t.is(stats.jpeg[1].outputPath, path.join("img/97854483-328.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/a705425c-164.jpeg"));
+  t.is(stats.jpeg[1].outputPath, path.join("img/a705425c-328.jpeg"));
 });
 
 test("Keep a cache, reuse with same file names and options", async t => {
@@ -545,14 +545,14 @@ test("Using `jpg` in formats Issue #64", async t => {
   t.deepEqual(stats, {
     jpeg: [
       {
-        filename: '97854483-1280.jpeg',
+        filename: 'a705425c-1280.jpeg',
         format: 'jpeg',
         height: 853,
-        outputPath: path.join('img/97854483-1280.jpeg'),
+        outputPath: path.join('img/a705425c-1280.jpeg'),
         size: 276231,
         sourceType: "image/jpeg",
-        srcset: '/img/97854483-1280.jpeg 1280w',
-        url: '/img/97854483-1280.jpeg',
+        srcset: '/img/a705425c-1280.jpeg 1280w',
+        url: '/img/a705425c-1280.jpeg',
         width: 1280,
       },
     ]

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ test("Use 'auto' format as original", async t => {
 
   t.is(stats.auto, undefined);
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -181,7 +181,7 @@ test("Try to use a width larger than original", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -192,7 +192,7 @@ test("Try to use a width larger than original (two sizes)", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -203,7 +203,7 @@ test("Try to use a width larger than original (with a null in there)", async t =
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -214,7 +214,7 @@ test("Just falsy width", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -226,7 +226,7 @@ test("Use exact same width as original", async t => {
   });
   t.is(stats.jpeg.length, 1);
   // breaking change in 0.5: always use width in filename
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/Bok0Qhed6a-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -237,7 +237,7 @@ test("Try to use a width larger than original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/70DaY9n7K_-1280.jpeg");
+  t.is(stats.jpeg[0].url, "/img/Bok0Qhed6a-1280.jpeg");
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -248,7 +248,7 @@ test("Use exact same width as original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/70DaY9n7K_-1280.jpeg"); // no width in filename
+  t.is(stats.jpeg[0].url, "/img/Bok0Qhed6a-1280.jpeg"); // no width in filename
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -270,19 +270,20 @@ test("Use custom function to define file names", async (t) => {
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-70DaY9n7K_-600.jpeg"));
-  t.is(stats.jpeg[0].url, "/img/bio-2017-70DaY9n7K_-600.jpeg");
-  t.is(stats.jpeg[0].srcset, "/img/bio-2017-70DaY9n7K_-600.jpeg 600w");
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-Bok0Qhed6a-600.jpeg"));
+  t.is(stats.jpeg[0].url, "/img/bio-2017-Bok0Qhed6a-600.jpeg");
+  t.is(stats.jpeg[0].srcset, "/img/bio-2017-Bok0Qhed6a-600.jpeg 600w");
   t.is(stats.jpeg[0].width, 600);
-  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-70DaY9n7K_-1280.jpeg"));
-  t.is(stats.jpeg[1].url, "/img/bio-2017-70DaY9n7K_-1280.jpeg");
-  t.is(stats.jpeg[1].srcset, "/img/bio-2017-70DaY9n7K_-1280.jpeg 1280w");
+  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-Bok0Qhed6a-1280.jpeg"));
+  t.is(stats.jpeg[1].url, "/img/bio-2017-Bok0Qhed6a-1280.jpeg");
+  t.is(stats.jpeg[1].srcset, "/img/bio-2017-Bok0Qhed6a-1280.jpeg 1280w");
   t.is(stats.jpeg[1].width, 1280);
 });
 
 test("Unavatar test", t => {
   let stats = eleventyImage.statsByDimensionsSync("https://unavatar.now.sh/twitter/zachleat?fallback=false", 400, 400, {
-    widths: [75]
+    widths: [75],
+    remoteAssetContent: 'remote asset content'
   });
 
   t.is(stats.webp.length, 1);
@@ -386,7 +387,7 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are smaller 
 
   // this won’t upscale so it will miss out on higher resolution images but there won’t be any broken image URLs in the output
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("img/70DaY9n7K_-164.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/Bok0Qhed6a-164.jpeg"));
 });
 
 test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger than real)", t => {
@@ -396,8 +397,8 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger t
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("img/70DaY9n7K_-164.jpeg"));
-  t.is(stats.jpeg[1].outputPath, path.join("img/70DaY9n7K_-328.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/Bok0Qhed6a-164.jpeg"));
+  t.is(stats.jpeg[1].outputPath, path.join("img/Bok0Qhed6a-328.jpeg"));
 });
 
 test("Keep a cache, reuse with same file names and options", async t => {
@@ -545,14 +546,14 @@ test("Using `jpg` in formats Issue #64", async t => {
   t.deepEqual(stats, {
     jpeg: [
       {
-        filename: '70DaY9n7K_-1280.jpeg',
+        filename: 'Bok0Qhed6a-1280.jpeg',
         format: 'jpeg',
         height: 853,
-        outputPath: path.join('img/70DaY9n7K_-1280.jpeg'),
+        outputPath: path.join('img/Bok0Qhed6a-1280.jpeg'),
         size: 276231,
         sourceType: "image/jpeg",
-        srcset: '/img/70DaY9n7K_-1280.jpeg 1280w',
-        url: '/img/70DaY9n7K_-1280.jpeg',
+        srcset: '/img/Bok0Qhed6a-1280.jpeg 1280w',
+        url: '/img/Bok0Qhed6a-1280.jpeg',
         width: 1280,
       },
     ]

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ test("Use 'auto' format as original", async t => {
 
   t.is(stats.auto, undefined);
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -181,7 +181,7 @@ test("Try to use a width larger than original", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -192,7 +192,7 @@ test("Try to use a width larger than original (two sizes)", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -203,7 +203,7 @@ test("Try to use a width larger than original (with a null in there)", async t =
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -214,7 +214,7 @@ test("Just falsy width", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -226,7 +226,7 @@ test("Use exact same width as original", async t => {
   });
   t.is(stats.jpeg.length, 1);
   // breaking change in 0.5: always use width in filename
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/70DaY9n7K_-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -237,7 +237,7 @@ test("Try to use a width larger than original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/e1d4b79f-1280.jpeg");
+  t.is(stats.jpeg[0].url, "/img/70DaY9n7K_-1280.jpeg");
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -248,7 +248,7 @@ test("Use exact same width as original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/e1d4b79f-1280.jpeg"); // no width in filename
+  t.is(stats.jpeg[0].url, "/img/70DaY9n7K_-1280.jpeg"); // no width in filename
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -270,13 +270,13 @@ test("Use custom function to define file names", async (t) => {
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-e1d4b79f-600.jpeg"));
-  t.is(stats.jpeg[0].url, "/img/bio-2017-e1d4b79f-600.jpeg");
-  t.is(stats.jpeg[0].srcset, "/img/bio-2017-e1d4b79f-600.jpeg 600w");
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-70DaY9n7K_-600.jpeg"));
+  t.is(stats.jpeg[0].url, "/img/bio-2017-70DaY9n7K_-600.jpeg");
+  t.is(stats.jpeg[0].srcset, "/img/bio-2017-70DaY9n7K_-600.jpeg 600w");
   t.is(stats.jpeg[0].width, 600);
-  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-e1d4b79f-1280.jpeg"));
-  t.is(stats.jpeg[1].url, "/img/bio-2017-e1d4b79f-1280.jpeg");
-  t.is(stats.jpeg[1].srcset, "/img/bio-2017-e1d4b79f-1280.jpeg 1280w");
+  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-70DaY9n7K_-1280.jpeg"));
+  t.is(stats.jpeg[1].url, "/img/bio-2017-70DaY9n7K_-1280.jpeg");
+  t.is(stats.jpeg[1].srcset, "/img/bio-2017-70DaY9n7K_-1280.jpeg 1280w");
   t.is(stats.jpeg[1].width, 1280);
 });
 
@@ -386,7 +386,7 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are smaller 
 
   // this won’t upscale so it will miss out on higher resolution images but there won’t be any broken image URLs in the output
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("img/e1d4b79f-164.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/70DaY9n7K_-164.jpeg"));
 });
 
 test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger than real)", t => {
@@ -396,8 +396,8 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger t
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("img/e1d4b79f-164.jpeg"));
-  t.is(stats.jpeg[1].outputPath, path.join("img/e1d4b79f-328.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/70DaY9n7K_-164.jpeg"));
+  t.is(stats.jpeg[1].outputPath, path.join("img/70DaY9n7K_-328.jpeg"));
 });
 
 test("Keep a cache, reuse with same file names and options", async t => {
@@ -545,14 +545,14 @@ test("Using `jpg` in formats Issue #64", async t => {
   t.deepEqual(stats, {
     jpeg: [
       {
-        filename: 'e1d4b79f-1280.jpeg',
+        filename: '70DaY9n7K_-1280.jpeg',
         format: 'jpeg',
         height: 853,
-        outputPath: path.join('img/e1d4b79f-1280.jpeg'),
+        outputPath: path.join('img/70DaY9n7K_-1280.jpeg'),
         size: 276231,
         sourceType: "image/jpeg",
-        srcset: '/img/e1d4b79f-1280.jpeg 1280w',
-        url: '/img/e1d4b79f-1280.jpeg',
+        srcset: '/img/70DaY9n7K_-1280.jpeg 1280w',
+        url: '/img/70DaY9n7K_-1280.jpeg',
         width: 1280,
       },
     ]

--- a/test/test.js
+++ b/test/test.js
@@ -170,7 +170,7 @@ test("Use 'auto' format as original", async t => {
 
   t.is(stats.auto, undefined);
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -181,7 +181,7 @@ test("Try to use a width larger than original", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -192,7 +192,7 @@ test("Try to use a width larger than original (two sizes)", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -203,7 +203,7 @@ test("Try to use a width larger than original (with a null in there)", async t =
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -214,7 +214,7 @@ test("Just falsy width", async t => {
     outputDir: "./test/img/"
   });
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -226,7 +226,7 @@ test("Use exact same width as original", async t => {
   });
   t.is(stats.jpeg.length, 1);
   // breaking change in 0.5: always use width in filename
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/a705425c-1280.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/e1d4b79f-1280.jpeg"));
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -237,7 +237,7 @@ test("Try to use a width larger than original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/a705425c-1280.jpeg");
+  t.is(stats.jpeg[0].url, "/img/e1d4b79f-1280.jpeg");
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -248,7 +248,7 @@ test("Use exact same width as original (statsSync)", t => {
   });
 
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].url, "/img/a705425c-1280.jpeg"); // no width in filename
+  t.is(stats.jpeg[0].url, "/img/e1d4b79f-1280.jpeg"); // no width in filename
   t.is(stats.jpeg[0].width, 1280);
 });
 
@@ -270,13 +270,13 @@ test("Use custom function to define file names", async (t) => {
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-a705425c-600.jpeg"));
-  t.is(stats.jpeg[0].url, "/img/bio-2017-a705425c-600.jpeg");
-  t.is(stats.jpeg[0].srcset, "/img/bio-2017-a705425c-600.jpeg 600w");
+  t.is(stats.jpeg[0].outputPath, path.join("test/img/bio-2017-e1d4b79f-600.jpeg"));
+  t.is(stats.jpeg[0].url, "/img/bio-2017-e1d4b79f-600.jpeg");
+  t.is(stats.jpeg[0].srcset, "/img/bio-2017-e1d4b79f-600.jpeg 600w");
   t.is(stats.jpeg[0].width, 600);
-  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-a705425c-1280.jpeg"));
-  t.is(stats.jpeg[1].url, "/img/bio-2017-a705425c-1280.jpeg");
-  t.is(stats.jpeg[1].srcset, "/img/bio-2017-a705425c-1280.jpeg 1280w");
+  t.is(stats.jpeg[1].outputPath, path.join("test/img/bio-2017-e1d4b79f-1280.jpeg"));
+  t.is(stats.jpeg[1].url, "/img/bio-2017-e1d4b79f-1280.jpeg");
+  t.is(stats.jpeg[1].srcset, "/img/bio-2017-e1d4b79f-1280.jpeg 1280w");
   t.is(stats.jpeg[1].width, 1280);
 });
 
@@ -386,7 +386,7 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are smaller 
 
   // this won’t upscale so it will miss out on higher resolution images but there won’t be any broken image URLs in the output
   t.is(stats.jpeg.length, 1);
-  t.is(stats.jpeg[0].outputPath, path.join("img/a705425c-164.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/e1d4b79f-164.jpeg"));
 });
 
 test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger than real)", t => {
@@ -396,8 +396,8 @@ test("Sync by dimension with jpeg input (wrong dimensions, supplied are larger t
   });
 
   t.is(stats.jpeg.length, 2);
-  t.is(stats.jpeg[0].outputPath, path.join("img/a705425c-164.jpeg"));
-  t.is(stats.jpeg[1].outputPath, path.join("img/a705425c-328.jpeg"));
+  t.is(stats.jpeg[0].outputPath, path.join("img/e1d4b79f-164.jpeg"));
+  t.is(stats.jpeg[1].outputPath, path.join("img/e1d4b79f-328.jpeg"));
 });
 
 test("Keep a cache, reuse with same file names and options", async t => {
@@ -545,14 +545,14 @@ test("Using `jpg` in formats Issue #64", async t => {
   t.deepEqual(stats, {
     jpeg: [
       {
-        filename: 'a705425c-1280.jpeg',
+        filename: 'e1d4b79f-1280.jpeg',
         format: 'jpeg',
         height: 853,
-        outputPath: path.join('img/a705425c-1280.jpeg'),
+        outputPath: path.join('img/e1d4b79f-1280.jpeg'),
         size: 276231,
         sourceType: "image/jpeg",
-        srcset: '/img/a705425c-1280.jpeg 1280w',
-        url: '/img/a705425c-1280.jpeg',
+        srcset: '/img/e1d4b79f-1280.jpeg 1280w',
+        url: '/img/e1d4b79f-1280.jpeg',
         width: 1280,
       },
     ]


### PR DESCRIPTION
Fixes #51
Fixes #115

If the processed file exists in the output folder, processing it is skipped. Thus persisting the cache.
Output images are reprocessed if `useCache: false`

Because we are using cache across runs, we can't use just the file name for calculating hash:
- Sharp options can change between runs
- The image content can change

So I had to change hash to use image content + sharp options. This hashing is done with the built-in crypto library, using SHA1 because it seemed to have the highest throughput.

This PR was meant to solve #115, but it solves #51 too by accident 😂 

For testing, please use:
```bash
npm r @11ty/eleventy-img 
npm i zeroby0/eleventy-img#cache
```
**See summary** of changes: https://github.com/11ty/eleventy-img/pull/116#issuecomment-894613678
**See it in action**: https://github.com/zeroby0/demo-eleventy-img-cache