### PR TITLE
Fix statsSync format

### DIFF
--- a/img.js
+++ b/img.js
@@ -429,7 +429,12 @@ Object.defineProperty(module.exports, "concurrency", {
  */
 function statsSync(src, opts) {
   let dimensions = getImageSize(src);
-  return getFullStats(src, dimensions, opts);
+  let metadata = {
+    width:  dimensions.width,
+    height: dimensions.height,
+    format: dimensions.type,
+  };
+  return getFullStats(src, metadata, opts);
 }
 
 function statsByDimensionsSync(src, width, height, opts) {


### PR DESCRIPTION
`Image.statsSync` doesn't work with `svg` because `image-size` returns `type` instead of `format` and `getFullStats` expects `metadata.format`.

```
EleventyImg Skipping SVG output for './src/images/sd-logo-horizontals-rgb.svg': received raster input. +0ms
```

```
getImageSize(src)
> { height: 32, width: 118, type: 'svg' }
```

Config:

```javascript
function imageShortcode(src, alt, cls) {
  const Image = require("@11ty/eleventy-img")
  let options = {
    widths: [null],
    formats: ["avif", "webp", "png", "svg"],
    svgShortCircuit: true,
    urlPath: `${pathPrefix}/img/`,
    outputDir: 'public/img/',
  }
  Image(src, options)
  const metadata = Image.statsSync(src, options)
  const imageAttributes = {
    alt,
    class: cls,
    loading: "lazy",
    decoding: "async",
  }
  return Image.generateHTML(metadata, imageAttributes)
}

eleventyConfig.addNunjucksShortcode("image", imageShortcode)
```