### PR TITLE
Adds ability to use absolute file paths on Windows. Fixes #137

### DIFF
--- a/img.js
+++ b/img.js
@@ -93,11 +93,18 @@ class Util {
     return obj;
   }
 
-  static isFullUrl(url) {
+  static isRemoteUrl(url) {
     try {
-      new URL(url);
-      return true;
-    } catch(e) {
+      const validUrl = new URL(url);
+
+      if (validUrl.protocol.startsWith("https:") || validUrl.protocol.startsWith("http:")) {
+        return true;
+      }
+
+      return false;
+    } catch(e)
+
+    {
       // invalid url OR local path
       return false;
     }
@@ -111,7 +118,7 @@ class Image {
     }
 
     this.src = src;
-    this.isRemoteUrl = typeof src === "string" && Util.isFullUrl(src);
+    this.isRemoteUrl = typeof src === "string" && Util.isRemoteUrl(src);
     this.options = Object.assign({}, globalOptions, options);
 
     if(this.isRemoteUrl) {
@@ -506,8 +513,8 @@ class Image {
   * any files.
   */
   static statsSync(src, opts) {
-    if(typeof src === "string" && Util.isFullUrl(src)) {
-      throw new Error("`statsSync` is not supported with full URL sources. Use `statsByDimensionsSync` instead.");
+    if(typeof src === "string" && Util.isRemoteUrl(src)) {
+      throw new Error("`statsSync` is not supported with remote sources. Use `statsByDimensionsSync` instead.");
     }
 
     let dimensions = getImageSize(src);
@@ -586,7 +593,7 @@ function queueImage(src, opts) {
 
   let promise = processingQueue.add(async () => {
     if(typeof src === "string" && opts && opts.statsOnly) {
-      if(Util.isFullUrl(src)) {
+      if(Util.isRemoteUrl(src)) {
         if(!opts.remoteImageMetadata || !opts.remoteImageMetadata.width || !opts.remoteImageMetadata.height) {
           throw new Error("When using `statsOnly` and remote images, you must supply a `remoteImageMetadata` object with { width, height, format? }");
         }

--- a/test/test.js
+++ b/test/test.js
@@ -805,3 +805,26 @@ test("statsOnly using remote image, no urlFormat", async t => {
   });
 });
 
+test("src is recognized as local when using absolute path on Windows", t => {
+  let image = new eleventyImage.Image("C:\\image.jpg");
+
+  t.is(image.isRemoteUrl, false);
+});
+
+test("src is recognized as local when using absolute path on POSIX", t => {
+  let image = new eleventyImage.Image("/home/user/image.jpg");
+
+  t.is(image.isRemoteUrl, false);
+});
+
+test("src is recognized as remote when using https scheme", t => {
+  let image = new eleventyImage.Image("https://example.com/image.jpg");
+
+  t.is(image.isRemoteUrl, true);
+});
+
+test("src is recognized as remote when using http scheme", t => {
+  let image = new eleventyImage.Image("http://example.com/image.jpg");
+
+  t.is(image.isRemoteUrl, true);
+});


### PR DESCRIPTION
#137 explains the issues when using absolute file paths on Windows. With these changes, such usage is now possible.

I have also renamed `isFullUrl` to `isRemoteUrl`. I thought the name was misleading because the intent and the name seem to be different: the intent is to find out whether the value of constructor parameter `src`, passed to the method as `url`, points to a remote resource or not, as evidenced by the return value being assigned to a property named `isRemoteUrl`, but the method name suggests that this method indicates whether a URL is a "full" one (is there a half URL?). As this is not part of the public API of this package, however, it's less of a concern and I'm happy to revert that part if there is objection to the rename.