### PR TITLE
Remove dependency: bash64url

### DIFF
--- a/img.js
+++ b/img.js
@@ -4,7 +4,6 @@ const fsp = fs.promises;
 const { URL } = require("url");
 const { createHash } = require("crypto");
 const {default: PQueue} = require("p-queue");
-const base64url = require("base64url");
 const getImageSize = require("image-size");
 const sharp = require("sharp");
 const debug = require("debug")("EleventyImg");
@@ -338,7 +337,12 @@ class Image {
 
     // TODO allow user to update other things into hash
 
-    return base64url.encode(hash.digest()).substring(0, this.options.hashLength);
+    // Get hash in base64, and make it URL safe.
+    // NOTE: When increasing minimum Node version to 14,
+    // replace with hash.digest('base64url')
+    let base64hash =  hash.digest('base64').replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+
+    return base64hash.substring(0, this.options.hashLength);
   }
 
   getStat(outputFormat, width, height) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/11ty/eleventy-img#readme",
   "dependencies": {
     "@11ty/eleventy-cache-assets": "^2.3.0",
-    "base64url": "^3.0.1",
     "debug": "^4.3.3",
     "image-size": "^1.0.1",
     "p-queue": "^6.6.2",


### PR DESCRIPTION
Removes the base64url dependency. It was added by me in [`2f0f27e`: Support node v12 base64url](https://github.com/11ty/eleventy-img/commit/2f0f27e786f357fcb7298f5b128aea4d52ba2806). 

The base64url package is **Safe** to use at the moment, but I suggest removing it to prevent supply chain attacks.

