### PR TITLE
Fix #146. Cache is valid while fetching assets.

### DIFF
--- a/img.js
+++ b/img.js
@@ -311,7 +311,14 @@ class Image {
 
       // add whether or not the cached asset is still valid per the cache duration (work with empty duration or "*")
       if(this.options.useCacheValidityInHash && this.isRemoteUrl && this.assetCache && this.cacheOptions) {
-        hash.update(`ValidCache:${this.assetCache.isCacheValid(this.cacheOptions.duration)}`);
+        if(this.assetCache.needsToFetch()) {
+          // Assume cache is valid if asset is yet to be fetched. See #146.
+          // isCacheValid returns false while asset is being fetched
+          // and that results in a different hash.
+          hash.update(`ValidCache:true`);
+        } else {
+          hash.update(`ValidCache:${this.assetCache.isCacheValid(this.cacheOptions.duration)}`);
+        }
       }
     }
 


### PR DESCRIPTION
~~Fixes #146.~~

While calculating hash,  `assetCache.isCacheValid()` returns `false` while the image is being fetched, and that returns in a different hash digest.

When 11ty is run the second time, `assetCache.isCacheValid()` returns `true` which generates a different hash in the filename, resulting in 404s.

This PR fixes the race condition by marking cache valid while the image is being fetched. More concretely, while `assetCache.needsToFetch()` returns true.

# Don't merge
Please see discussion below. 
