### PR TITLE
substr is deprecated

### DIFF
--- a/img.js
+++ b/img.js
@@ -299,7 +299,7 @@ class Image {
 
       // remove all newlines for hashing for better cross-OS hash compatibility (Issue #122)
       let fileContentsStr = fileContents.toString();
-      let firstFour = fileContentsStr.trim().substr(0, 5);
+      let firstFour = fileContentsStr.trim().slice(0, 5);
       if(firstFour === "<svg " || firstFour === "<?xml") {
         fileContents = fileContentsStr.replace(/\r|\n/g, '');
       }
@@ -342,7 +342,7 @@ class Image {
     // replace with hash.digest('base64url')
     let base64hash =  hash.digest('base64').replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
 
-    return base64hash.substring(0, this.options.hashLength);
+    return base64hash.slice(0, this.options.hashLength);
   }
 
   getStat(outputFormat, width, height) {

--- a/test/test.js
+++ b/test/test.js
@@ -323,7 +323,7 @@ test("Upscale an SVG, Issue #32", async t => {
   });
 
   t.is(stats.png.length, 1);
-  t.is(stats.png[0].filename.substr(-9), "-3000.png"); // should include width in filename
+  t.is(stats.png[0].filename.slice(-9), "-3000.png"); // should include width in filename
   t.is(stats.png[0].width, 3000);
   t.is(stats.png[0].height, 4179);
 });
@@ -337,7 +337,7 @@ test("Upscale an SVG (disallowed in option), Issue #32", async t => {
   });
 
   t.is(stats.png.length, 1);
-  t.not(stats.png[0].filename.substr(-9), "-3000.png"); // should not include width in filename
+  t.not(stats.png[0].filename.slice(-9), "-3000.png"); // should not include width in filename
   t.is(stats.png[0].width, 1569);
   t.is(stats.png[0].height, 2186);
 });


### PR DESCRIPTION
[`String.prototype.substr()` is deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr).

This PR replaces `substr` with `slice`. Also replaces `substring` with `slice` for consistency.

[Docs for String.prototype.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice).

