### PR TITLE
Add gif to format priority list

### DIFF
--- a/generate-html.js
+++ b/generate-html.js
@@ -3,7 +3,7 @@ const DEFAULT_ATTRIBUTES = {
   // decoding: "async",
 };
 
-const LOWSRC_FORMAT_PREFERENCE = ["jpeg", "png", "svg", "webp", "avif"];
+const LOWSRC_FORMAT_PREFERENCE = ["gif", "jpeg", "png", "svg", "webp", "avif"];
 
 /*
   Returns:


### PR DESCRIPTION
I found that the `generateHTML` function always defaults to gif, even when webp was available. Adding gif to the `LOWSRC_FORMAT_PREFERENCE` list seems to resolve that.