### PR TITLE
Update generate-html.js (issue #165)

### DIFF
--- a/generate-html.js
+++ b/generate-html.js
@@ -56,7 +56,7 @@ function generateObject(metadata, attributes = {}, options = {}) {
     throw new Error(`Could not find the lowest <img> source for responsive markup for ${originalSrc}`);
   }
 
-  attributes.src = lowsrc[0].url;
+  attributes.src = lowsrc[lowsrc.length - 1].url;
   attributes.width = lowsrc[lowsrc.length - 1].width;
   attributes.height = lowsrc[lowsrc.length - 1].height;
 


### PR DESCRIPTION
'attributes.src` didn't match `width` and `height`. This PR fixes it.

Fixes issue #165 (https://github.com/11ty/eleventy-img/issues/165)