### PR TITLE
Update minimal Node requirement in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # eleventy-img
 
-Requires Node 12+
+Requires Node 14.15+
 
 Low level utility to perform build-time image transformations for both vector and raster images. Output multiple sizes, save multiple formats, cache remote images locally. Uses the [sharp](https://sharp.pixelplumbing.com/) image processor.
 


### PR DESCRIPTION
Changed minimal Node requirement in README.md so to reflect what's stated in [v3 release tag](https://github.com/11ty/eleventy-img/releases/tag/v3.0.0).