### PR TITLE
Fix incorrectly large reported height for animated gifs

### DIFF
--- a/img.js
+++ b/img.js
@@ -415,6 +415,15 @@ class Image {
       metadata.height = width;
     }
 
+    if(metadata.pageHeight) {
+      // When the { animated: true } option is provided to sharp, animated
+      // image formats like gifs or webp will have an inaccurate `height` value
+      // in their metadata which is actually the height of every single frame added together.
+      // In these cases, the metadata will contain an additional `pageHeight` property which
+      // is the height that the image should be displayed at.
+      metadata.height = metadata.pageHeight;
+    }
+
     for(let outputFormat of outputFormats) {
       if(!outputFormat || outputFormat === "auto") {
         throw new Error("When using statsSync or statsByDimensionsSync, `formats: [null | auto]` to use the native image format is not supported.");

--- a/test/test.js
+++ b/test/test.js
@@ -912,6 +912,7 @@ test("Animated gif", async t => {
 
   t.is(stats.gif.length, 1);
   t.is(stats.gif[0].width, 400);
+  t.is(stats.gif[0].height, 400);
   // it’s a big boi
   t.true( stats.gif[0].size > 1000*1000 );
 });


### PR DESCRIPTION
## The problem

I'm working on a site which uses the `eleventy-image` webc component and ran into an issue where animated gifs were getting ridiculously high `height` attributes set on them which would break the page.

It turns out this is because the base `height` value that sharp returns in its metadata for animated gifs is actually the sum of the height of every frame, meaning if you have a 720x720 animated gif with 100 frames in it, the reported height will come back as 72,000px. That doesn't seem helpful!

## The fix

Digging into [sharp's docs](https://sharp.pixelplumbing.com/api-input), the metadata will include an additional `pageHeight` value for animated formats which actually reflects the dimensions that the image will be displayed at.

I added a check to `Image.getFullStats` to swap in this `pageHeight` value as the official height of the image when present, and that seems to have done the trick.