### PR TITLE
 Upgrade minimum version of sharp to 0.32.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "entities": "^4.4.0",
     "image-size": "^1.0.2",
     "p-queue": "^6.6.2",
-    "sharp": "^0.32.0"
+    "sharp": "^0.32.5"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",


### PR DESCRIPTION
I'm unsure how many people will be processing untrusted input images via 11ty, however I highly recommend a new patch release is published with v0.32.5 as a minimum version of sharp (more details available shortly).