### PR TITLE
Generate gif as lowest priority source

### DIFF
--- a/generate-html.js
+++ b/generate-html.js
@@ -5,7 +5,7 @@ const DEFAULT_ATTRIBUTES = {
   // decoding: "async",
 };
 
-const LOWSRC_FORMAT_PREFERENCE = ["jpeg", "png", "svg", "webp", "avif"];
+const LOWSRC_FORMAT_PREFERENCE = ["gif", "jpeg", "png", "svg", "webp", "avif"];
 
 /*
   Returns:

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -247,6 +247,16 @@ test("Image markup (animated gif, two formats)", async t => {
   }), `<picture><source type="image/webp" srcset="/img/YQVTYq1wRQ-400.webp 400w"><img alt="" src="/img/YQVTYq1wRQ-400.gif" width="400" height="400"></picture>`);
 });
 
+test("Image markup (two formats, neither priority defined)", async t => {
+  let results = await eleventyImage("./test/earth-animated.gif", {
+    dryRun: true,
+    formats: ["tif", "heic"]
+  });
+
+  let e = t.throws(() => generateHTML(results, { alt: "" }));
+  t.true(e.message.startsWith("Could not find the lowest <img>"));
+});
+
 test("Image markup (escaped `alt`)", async t => {
   let results = await eleventyImage("./test/bio-2017.jpg", {
     formats: ["auto"],

--- a/test/test-markup.js
+++ b/test/test-markup.js
@@ -239,11 +239,12 @@ test("Image markup (animated gif)", async t => {
 test("Image markup (animated gif, two formats)", async t => {
   let results = await eleventyImage("./test/earth-animated.gif", {
     dryRun: true,
-    formats: ["tiff", "auto"]
+    formats: ["webp", "auto"]
   });
 
-  let e = t.throws(() => generateHTML(results, { alt: "" }));
-  t.true(e.message.startsWith("Could not find the lowest <img>"));
+  t.is(generateHTML(results, {
+    alt: ""
+  }), `<picture><source type="image/webp" srcset="/img/YQVTYq1wRQ-400.webp 400w"><img alt="" src="/img/YQVTYq1wRQ-400.gif" width="400" height="400"></picture>`);
 });
 
 test("Image markup (escaped `alt`)", async t => {


### PR DESCRIPTION
Because I think I'm facing the same issue as #164, I updated @iamschulz's PR with tests and I'll respond to [#164#issuecomment-1409449689](https://github.com/11ty/eleventy-img/pull/164#issuecomment-1409449689) here:

My options are:
```javascript
			{
				widths: [640, 1280, "auto"],
				formats: ["webp", "auto"],
				sharpOptions: {
					animated: true
				},
				svgShortCircuit: true,
				outputDir: path.join(eleventyConfig.dir.output, "img"),
			}
```

The markup I got was this for a gif (line breaks added for readability):
```html
<picture>
<source type="image/gif" srcset="/img/k5UePY7Ry5-500.gif 500w" sizes="100vw">
<img loading="lazy" decoding="async" alt="Alt" title="Title" src="/img/k5UePY7Ry5-500.webp" width="500" height="205">
</picture>
```

The problem is that this puts the gif `<source>` ahead of the webp `<img>` fallback, which causes the user agent to prefer the gif version. This image was not downsampled, so no webp `<source>` was produced, but when it is produced, the order looks like this:
1. gif `<source>`
2. webp `<source>`
3. webp `<img>`

I would prefer:
1. webp `<source>`
2. gif `<source>`
3. gif `<img>`

As this would allow browsers that don't support `<picture>` and browsers that don't support webp to both fall back on gif while preferring webp in all other cases.

I noticed that the test that this change break is really testing for the `Could not find the lowest <img> source for responsive markup for undefined` branch so I re-added a specific test for that to replace the gif-specific behavior test.