### PR TITLE
Fix for issue 220 where SVG as broken because the Buffer is Uint8Array.

### DIFF
--- a/sample/sample-issue-220.js
+++ b/sample/sample-issue-220.js
@@ -1,0 +1,13 @@
+const eleventyImage = require("../img");
+
+(async () => {
+  let results = await eleventyImage("https://images.ctfassets.net/qbmf238cr6te/2ExPY7uYyafazH0IfFnpTD/610bce5faa1598685f2985d2062dcf1f/heyflow-logo.svg", {
+    formats: [null],
+    widths: [null],
+    sharpOptions: {
+      unlimited: true
+    }
+  });
+
+  console.log( results );
+})();

--- a/src/format-hooks/svg.js
+++ b/src/format-hooks/svg.js
@@ -3,16 +3,8 @@ const fsp = require("fs").promises;
 module.exports = async function createSvg(sharpInstance) {
   let input = sharpInstance.options.input;
   let svgBuffer = input.buffer;
-
   if(svgBuffer) { // remote URL already has buffer
-    let svgString = svgBuffer.toString("utf-8")
-
-    if(!svgString.includes('<svg')) {
-      // based on https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder#examples
-      let utf8decoder = new TextDecoder()
-      svgString = utf8decoder.decode(svgBuffer)
-    }
-    return svgString
+    return svgBuffer;
   } else { // local file system
     return fsp.readFile(input.file);
   }

--- a/src/format-hooks/svg.js
+++ b/src/format-hooks/svg.js
@@ -3,8 +3,16 @@ const fsp = require("fs").promises;
 module.exports = async function createSvg(sharpInstance) {
   let input = sharpInstance.options.input;
   let svgBuffer = input.buffer;
+
   if(svgBuffer) { // remote URL already has buffer
-    return svgBuffer.toString("utf-8");
+    let svgString = svgBuffer.toString("utf-8")
+
+    if(!svgString.includes('<svg')) {
+      // based on https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder#examples
+      let utf8decoder = new TextDecoder()
+      svgString = utf8decoder.decode(svgBuffer)
+    }
+    return svgString
   } else { // local file system
     return fsp.readFile(input.file);
   }


### PR DESCRIPTION
This is a fix for the issue #220.
I'm checking if the `svgString` contains the `<svg` string.
If not, [decode the TypedArray](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder#examples) using `TextDecoder`.

You can see the new `sample/sample-issue-220.js` file to test this (imho) edge case for yourself.