### PR TITLE
Avoid utf8 encoding binary image files in getHash.

### DIFF
--- a/img.js
+++ b/img.js
@@ -365,11 +365,17 @@ class Image {
     if(fs.existsSync(this.src)) {
       let fileContents = this.getFileContents();
 
-      // remove all newlines for hashing for better cross-OS hash compatibility (Issue #122)
-      let fileContentsStr = fileContents.toString();
-      let firstFour = fileContentsStr.trim().slice(0, 5);
-      if(firstFour === "<svg " || firstFour === "<?xml") {
-        fileContents = fileContentsStr.replace(/\r|\n/g, '');
+      // If the file starts with whitespace or the '<' character, it might be SVG.
+      // Otherwise, skip the expensive buffer.toString() call
+      // (no point in unicode encoding a binary file)
+      let fileContentsPrefix = fileContents.slice(0, 1).toString().trim();
+      if (!fileContentsPrefix || fileContentsPrefix[0] == "<") {
+        // remove all newlines for hashing for better cross-OS hash compatibility (Issue #122)
+        let fileContentsStr = fileContents.toString();
+        let firstFour = fileContentsStr.trim().slice(0, 5);
+        if(firstFour === "<svg " || firstFour === "<?xml") {
+          fileContents = fileContentsStr.replace(/\r|\n/g, '');
+        }
       }
 
       hash.update(fileContents);


### PR DESCRIPTION
Here are 2 profiles of building the same website, first [without the PR](https://share.firefox.dev/4bhBtP6), and then [with the PR](https://share.firefox.dev/3Wlxqgd).

With the PR, `getHash` takes 3.1% (30.7ms) of the total build time. Without the PR, it took 34% (549ms) of the total time.

The profile without the PR shows 518ms spent in buffer.toString. 

Using [samply](https://github.com/mstange/samply) to capture [a profile showing the native code](https://share.firefox.dev/44pcV4y), I could see that almost all the time spent in `toString` is spent in `node::StringBytes::Encode`.

Profiles were captured using `node --cpu-prof node_modules/.bin/eleventy` and then loaded in the [Firefox Profiler](https://profiler.firefox.com/) to visualize and share them.