### PR TITLE
bump image-size minimum version for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "brotli-size": "^4.0.0",
     "debug": "^4.4.0",
     "entities": "^6.0.0",
-    "image-size": "^1.2.0",
+    "image-size": "^1.2.1",
     "p-queue": "^6.6.2",
     "sharp": "^0.33.5"
   },


### PR DESCRIPTION
Update image-size to patch [this vulnerability](https://github.com/advisories/GHSA-m5qc-5hw7-8vg7).