### PR TITLE
Fix poor in-memory cache performance due to accidental mutation of global object used in cache keys

### DIFF
--- a/img.js
+++ b/img.js
@@ -6,7 +6,7 @@ import BuildLogger from "./src/build-logger.js";
 import Util from "./src/util.js";
 import Image from "./src/image.js";
 import DirectoryManager from "./src/directory-manager.js";
-import { DEFAULTS as GLOBAL_OPTIONS } from "./src/global-options.js";
+import { getDefaults } from "./src/global-options.js";
 import { memCache, diskCache } from "./src/caches.js";
 
 const debug = debugUtil("Eleventy:Image");
@@ -17,7 +17,7 @@ let directoryManager = new DirectoryManager();
 
 /* Queue */
 let processingQueue = new PQueue({
-  concurrency: GLOBAL_OPTIONS.concurrency
+  concurrency: getDefaults().concurrency
 });
 processingQueue.on("active", () => {
   debug( `Concurrency: ${processingQueue.concurrency}, Size: ${processingQueue.size}, Pending: ${processingQueue.pending}` );

--- a/src/global-options.js
+++ b/src/global-options.js
@@ -5,7 +5,7 @@ import eleventyImage from "../img.js";
 import Util from "./util.js";
 import svgHook from "./format-hooks/svg.js";
 
-export const DEFAULTS = {
+export const getDefaults = () => ({
   widths: ["auto"],
   formats: ["webp", "jpeg"], // "png", "svg", "avif"
 
@@ -96,7 +96,7 @@ export const DEFAULTS = {
 
   // v5.0.0 Removed `extensions`, option to override output format with new file extension. It wasn’t being used anywhere or documented.
   // v6.0.0, removed `useCacheValidityInHash: true` see https://github.com/11ty/eleventy-img/issues/146#issuecomment-2555741376
-};
+});
 
 export function getGlobalOptions(eleventyConfig, options, via) {
   let directories = eleventyConfig.directories;

--- a/src/image.js
+++ b/src/image.js
@@ -12,7 +12,7 @@ import Util from "./util.js";
 import ImagePath from "./image-path.js";
 import { generateHTML } from "./generate-html.js";
 
-import { DEFAULTS as GLOBAL_OPTIONS } from "./global-options.js";
+import { getDefaults } from "./global-options.js";
 import { existsCache, memCache, diskCache } from "./caches.js";
 
 const debug = debugUtil("Eleventy:Image");
@@ -70,7 +70,7 @@ export default class Image {
     this.isRemoteUrl = typeof src === "string" && Util.isRemoteUrl(src);
 
     this.rawOptions = options;
-    this.options = Object.assign({}, GLOBAL_OPTIONS, options);
+    this.options = Object.assign({}, getDefaults(), options);
 
     // Compatible with eleventy-dev-server and Eleventy 3.0.0-alpha.7+ in serve mode.
     if(this.options.transformOnRequest && !this.options.urlFormat) {

--- a/test/test.js
+++ b/test/test.js
@@ -511,6 +511,17 @@ test("Keep a cache, reuse with same file names and options", async t => {
   t.deepEqual(stats1, stats2);
 });
 
+test("Keep a cache, reuse even after an image transform is completed (issue #312)", async t => {
+  // await the promises to allow the process to complete, which in issue #312 unexpectedly mutated an object used as a cache key
+  let promise1 = await eleventyImage("./test/bio-2017.jpg", { dryRun: true });
+  let promise2 = await eleventyImage("./test/bio-2017.jpg", { dryRun: true });
+  t.is(promise1, promise2);
+
+  let stats1 = await promise1;
+  let stats2 = await promise2;
+  t.deepEqual(stats1, stats2);
+});
+
 test("Keep a cache, reuse with same remote url and options", async t => {
   let promise1 = eleventyImage("https://www.zachleat.com/img/avatar-2017-big.png", { dryRun: true });
   let promise2 = eleventyImage("https://www.zachleat.com/img/avatar-2017-big.png", { dryRun: true });


### PR DESCRIPTION
Creates a new default options object whenever one is needed, to avoid inheriting mutations to a single global object that is reused for multiple images.

Fixes #312

Note: I've also prepared a fix for v6 (the current general availability version of this package) [here](https://github.com/sentience/eleventy-img/tree/fix-global-options-pollution). If a maintenance branch for v6 is created, I'm happy to open a separate PR to contribute this fix to the current version.