### PR TITLE
Strip buffers after writing to disk to reduce memory usage (issue #302)

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -854,10 +854,25 @@ export default class Image {
           throw e;
         }
       }
+    }).then(results => {
+      // Strip buffers to free memory (only if file was written to disk)
+      if(results) {
+        for(let format in results) {
+          if(Array.isArray(results[format])) {
+            for(let stat of results[format]) {
+              if(stat.outputPath && stat.buffer && !this.options.dryRun) {
+                delete stat.buffer;
+              }
+            }
+          }
+        }
+      }
+      return results;
     });
 
     return this.#queuePromise;
   }
+
 
   // Factory to return from cache if available
   static create(src, options = {}) {

--- a/test/test.js
+++ b/test/test.js
@@ -1277,3 +1277,14 @@ test("#105 Transparent format output filtering (no minimum transparency formats 
   // must include one of: svg, png, or gif
   t.deepEqual(Object.keys(stats), ["webp", "jpeg"]);
 });
+
+test("Buffer should be stripped after writing to disk", async t => {
+  let stats = await eleventyImage("./test/bio-2017.jpg", {
+    formats: ["jpeg"],
+    outputDir: "./test/img/"
+  });
+
+  t.truthy(stats.jpeg[0].width);
+  t.truthy(stats.jpeg[0].outputPath);
+  t.falsy(stats.jpeg[0].buffer);
+});


### PR DESCRIPTION
**EDIT: the approach in this PR didn't turn out to work well and is superseded by [PR 319](https://github.com/11ty/eleventy-img/pull/319).**

* This PR tries to reduce memory usage by stripping buffers (which turned out to be a dead end).
* The new PR does solve the problem by introducing a separate manifest cache.

***

This PR addresses issue #302 by removing image buffers from memory after files have been written to disk.

**Problem**
When processing many images, the memory cache retains image buffers even after they've been written to disk. This causes memory usage to grow linearly with the number of images processed, leading to builds failing on large sites.

**Solution**
After processing completes, strip the buffer property from results when:
- The file was written to disk (`outputPath` exists)
- Not in `dryRun` mode (which needs buffers)

The metadata (dimensions, URLs, paths) remains available for generating HTML.

**Testing**
- All existing tests pass
- Added test to verify buffers are stripped after writing to disk
- Tested on a site with 1000+ images - build completes successfully