### PR TITLE
Add support for sharpResizeOptions

### DIFF
--- a/src/global-options.js
+++ b/src/global-options.js
@@ -28,6 +28,7 @@ export const DEFAULTS = {
   sharpPngOptions: {}, // options passed to the Sharp png output method
   sharpJpegOptions: {}, // options passed to the Sharp jpeg output method
   sharpAvifOptions: {}, // options passed to the Sharp avif output method
+  sharpResizeOptions: {}, // options passed to the Sharp resize method
 
   formatHooks: {
     svg: svgHook,

--- a/src/image.js
+++ b/src/image.js
@@ -415,7 +415,8 @@ export default class Image {
       "sharpWebpOptions",
       "sharpPngOptions",
       "sharpJpegOptions",
-      "sharpAvifOptions"
+      "sharpAvifOptions",
+      "sharpResizeOptions"
     ].sort();
 
     let hashObject = {};
@@ -710,9 +711,9 @@ export default class Image {
 
         if(!isTransformResize) {
           if(stat.width < sharpMetadata.width || (this.options.svgAllowUpscale && sharpMetadata.format === "svg")) {
-            let resizeOptions = {
-              width: stat.width
-            };
+            let resizeOptions = Object.assign({
+              width: stat.width,
+            }, this.options.sharpResizeOptions);
 
             if(sharpMetadata.format !== "svg" || !this.options.svgAllowUpscale) {
               resizeOptions.withoutEnlargement = true;


### PR DESCRIPTION
Adds support for passing Sharp resize options. Notably, since Sharp now supports "Magic Kernel Sharp" downsizing kernel, that is more computationally efficient than the default Lanczos-3 kernel, it may be beneficial to be able to choose the algorithm.