### PR TITLE
Decode HTML entities in image src when read back from HTML

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { decodeHTMLAttribute } from "entities";
 
 export default class Util {
   static KEYS = {
@@ -48,6 +49,10 @@ export default class Util {
     }
 
     if(isViaHtml) {
+      // This reference came from HTML, so decode HTML entities in the attribute
+      // value (e.g. `rose&amp;rose.jpg` => `rose&rose.jpg`) before resolving the
+      // path, mirroring how a browser reads the attribute. See #307.
+      src = decodeHTMLAttribute(src);
       src = decodeURIComponent(src);
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -707,6 +707,23 @@ test("Sorted object keys", async t => {
   });
 });
 
+test("normalizeImageSource decodes HTML entities in an HTML `src` #307", t => {
+  // A file named `rose&rose.jpg` is written into HTML as `rose&amp;rose.jpg`.
+  // When reading it back out of the built HTML we must decode the entity so the
+  // resolved path points at the real file on disk.
+  t.is(Util.normalizeImageSource({ input: "src", inputPath: "src/index.html" }, "rose&amp;rose.jpg", {
+    isViaHtml: true,
+  }), path.join("src", "rose&rose.jpg"));
+
+  // Numeric entities decode too.
+  t.is(Util.normalizeImageSource({ input: "src", inputPath: "src/index.html" }, "rose&#38;rose.jpg", {
+    isViaHtml: true,
+  }), path.join("src", "rose&rose.jpg"));
+
+  // Without the isViaHtml flag the value is not entity-decoded.
+  t.is(Util.normalizeImageSource({ input: "src", inputPath: "src/index.html" }, "rose&rose.jpg"), path.join("src", "rose&rose.jpg"));
+});
+
 test("widths array should be ignored in hashing", t => {
   let stats = eleventyImage.statsSync("./test/bio-2017.jpg", {
     widths: [1280]


### PR DESCRIPTION
The transform plugin (eleventyImageTransformPlugin) reads image sources back out of the built HTML. A file whose name contains an ampersand, like rose&rose.jpg, has to be written into HTML as an escaped attribute:

    <img src="rose&amp;rose.jpg" alt="By any other name">

When the plugin read that attribute it passed the value through literally, so it tried to stat a file called `rose&amp;rose.jpg`, which does not exist, and the build failed:

    [11ty] 3. ENOENT: no such file or directory, stat 'rose&amp;rose.jpg'

Repro: an Eleventy site using eleventyImageTransformPlugin with an image whose filename contains an ampersand, referenced from HTML as `src="rose&amp;rose.jpg"`.

Util.normalizeImageSource already had an isViaHtml branch meant to decode the value coming from HTML, but it only ran decodeURIComponent, which handles URL percent-encoding and leaves HTML entities like `&amp;` untouched. This decodes the HTML entities first, using decodeHTMLAttribute from the entities package that is already a dependency (and is already used for the matching escape on the way out in generate-html.js). That mirrors how a browser reads the attribute: entity-decode the attribute value, then treat it as a path.

Added a unit test in test/test.js covering a named entity, a numeric entity, and the unflagged case that should not be decoded.

Fixes #307
